### PR TITLE
PGO-related fixes

### DIFF
--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -14,7 +14,7 @@ from distutils.errors import (CompileError, LinkError, UnknownFileError,
 from distutils.spawn import spawn
 from distutils.file_util import move_file
 from distutils.dir_util import mkpath
-from distutils.dep_util import newer_group
+from distutils.dep_util import newer_group, newer
 from distutils.util import split_quoted, execute
 from distutils import log
 # following import is for backward compatibility
@@ -571,7 +571,9 @@ class CCompiler:
                 src, ext = build[obj]
             except KeyError:
                 continue
-            self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
+            if newer(src, obj):
+                # some extensions share source files so we need to avoid compiling the same source multiple times
+                self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
 
         # Return *all* object filenames, not just the ones we just built.
         return objects

--- a/Lib/distutils/dep_util.py
+++ b/Lib/distutils/dep_util.py
@@ -11,7 +11,7 @@ from stat import ST_MTIME
 from distutils.errors import DistutilsFileError
 
 def newer(source, target):
-    """Tells if the target is newer than the source.
+    """Tells if the source is newer than the target.
 
     Return true if 'source' exists and is more recently modified than
     'target', or if 'source' exists and 'target' doesn't.

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -209,9 +209,10 @@ TCLTK_INCLUDES=	@TCLTK_INCLUDES@
 TCLTK_LIBS=	@TCLTK_LIBS@
 
 # The task to run while instrument when building the profile-opt target
-# We exclude unittests with -x that take a rediculious amount of time to
-# run in the instrumented training build or do not provide much value.
-PROFILE_TASK=-m test.regrtest --pgo -x test_asyncore test_gdb test_multiprocessing test_subprocess
+# We exclude unittests with -x that take a ridiculous amount of time to
+# run in the instrumented training build, do not provide much value
+# or fail randomly when run in parallel (test_epoll, test_selectors).
+PROFILE_TASK=-m test.regrtest --pgo -w $(EXTRATESTOPTS) -x test_asyncore test_gdb test_multiprocessing test_subprocess test_epoll test_selectors
 
 # report files for gcov / lcov coverage report
 COVERAGE_INFO=	$(abs_builddir)/coverage.info
@@ -437,7 +438,7 @@ build_all_generate_profile:
 
 run_profile_task:
 	: # FIXME: can't run for a cross build
-	$(LLVM_PROF_FILE) $(RUNSHARED) ./$(BUILDTAUTHON) $(PROFILE_TASK) || true
+	$(LLVM_PROF_FILE) _PYTHONNOSITEPACKAGES=1 $(RUNSHARED) ./$(BUILDTAUTHON) -E $(PROFILE_TASK)
 
 build_all_merge_profile:
 	$(LLVM_PROF_MERGER)

--- a/configure
+++ b/configure
@@ -1460,7 +1460,7 @@ Optional Features:
                           Build fat binary against Mac OS X SDK
   --enable-framework[=INSTALLDIR]
                           Build (MacOSX|Darwin) framework
-  --enable-shared         disable/enable building shared python library
+  --enable-shared         disable/enable building shared tauthon library
   --enable-profiling      enable C-level code profiling
   --enable-optimizations  Enable expensive optimizations (PGO, etc). Disabled
                           by default.
@@ -1468,7 +1468,7 @@ Optional Features:
   --enable-ipv6           Enable ipv6 (with ipv4) support
   --disable-ipv6          Disable ipv6 support
   --enable-big-digits[=BITS]
-                          use big digits for Python longs [[BITS=30]]
+                          use big digits for Tauthon longs [[BITS=30]]
   --enable-unicode[=ucs[24]]
                           Enable Unicode strings (default is ucs2)
 
@@ -1485,7 +1485,7 @@ Optional Packages:
   --without-gcc           never use gcc
   --with-icc              build with icc
   --with-cxx-main=<compiler>
-                          compile main() and link python executable with C++
+                          compile main() and link tauthon executable with C++
                           compiler
   --with-suffix=.exe      set executable suffix
   --with-pydebug          build with Py_DEBUG defined
@@ -3381,7 +3381,7 @@ $as_echo "#define _BSD_SOURCE 1" >>confdefs.h
   # From the perspective of Solaris, _XOPEN_SOURCE is not so much a
   # request to enable features supported by the standard as a request
   # to disable features not supported by the standard.  The best way
-  # for Python to use Solaris is simply to leave _XOPEN_SOURCE out
+  # for Tauthon to use Solaris is simply to leave _XOPEN_SOURCE out
   # entirely and define __EXTENSIONS__ instead.
   SunOS/*)
     define_xopen_source=no;;
@@ -5324,7 +5324,7 @@ $as_echo "$LIBRARY" >&6; }
 # (defined in the Makefiles). On Cygwin LDLIBRARY is the import library,
 # DLLLIBRARY is the shared (i.e., DLL) library.
 #
-# RUNSHARED is used to run shared python without installed libraries
+# RUNSHARED is used to run shared tauthon without installed libraries
 #
 # INSTSONAME is the name of the shared library that will be use to install
 # on the system - some systems like version suffix, others don't
@@ -5341,10 +5341,10 @@ DLLLIBRARY=''
 LDLIBRARYDIR=''
 RUNSHARED=''
 
-# LINKCC is the command that links the python executable -- default is $(CC).
+# LINKCC is the command that links the tauthon executable -- default is $(CC).
 # If CXX is set, and if it is needed to link a main function that was
 # compiled with CXX, LINKCC is CXX instead. Always using CXX is undesirable:
-# python might then depend on the C++ runtime
+# tauthon might then depend on the C++ runtime
 # This is altered for AIX in order to build the export list before
 # linking.
 
@@ -5450,7 +5450,7 @@ $as_echo_n "checking LDLIBRARY... " >&6; }
 # MacOSX framework builds need more magic. LDLIBRARY is the dynamic
 # library that we build, but we do not want to link against it (we
 # will find it with a -framework option). For this reason there is an
-# extra variable BLDLIBRARY against which Python and the extension
+# extra variable BLDLIBRARY against which Tauthon and the extension
 # modules are linked, BLDLIBRARY. This is normally the same as
 # LDLIBRARY, but empty for MacOSX framework builds.
 if test "$enable_framework"
@@ -5985,7 +5985,7 @@ fi
 # Optimizer/debugger flags
 # ------------------------
 # (The following bit of code is complicated enough - please keep things
-# indented properly.  Just pretend you're editing Python code. ;-)
+# indented properly.  Just pretend you're editing Tauthon code. ;-)
 
 # There are two parallel sets of case statements below, one that checks to
 # see if OPT was set and one that does BASECFLAGS setting based upon
@@ -6048,7 +6048,7 @@ UNIVERSAL_ARCH_FLAGS=
 # tweak BASECFLAGS based on compiler and platform
 case $GCC in
 yes)
-    # Python violates C99 rules, by casting between incompatible
+    # Tauthon violates C99 rules, by casting between incompatible
     # pointer types. GCC may generate bad code as a result of that,
     # so use -fno-strict-aliasing if supported.
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts -fno-strict-aliasing" >&5
@@ -8562,7 +8562,7 @@ _ACEOF
 # LDSHARED is the ld *command* used to create shared library
 # -- "cc -G" on SunOS 5.x, "ld -shared" on IRIX 5
 # (Shared libraries in this instance are shared modules to be loaded into
-# Python, as opposed to building Python itself as a shared library.)
+# Tauthon, as opposed to building Tauthon itself as a shared library.)
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking LDSHARED" >&5
 $as_echo_n "checking LDSHARED... " >&6; }
 if test -z "$LDSHARED"
@@ -8603,7 +8603,7 @@ then
 			LDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 			LDCXXSHARED="$LDCXXSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 		else
-			# No framework. Ignore undefined symbols, assuming they come from Python
+			# No framework. Ignore undefined symbols, assuming they come from Tauthon
 			LDSHARED="$LDSHARED -undefined suppress"
 			LDCXXSHARED="$LDCXXSHARED -undefined suppress"
 		fi ;;
@@ -8616,14 +8616,14 @@ then
 			LDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 			LDCXXSHARED="$LDCXXSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 		else
-			# No framework, use the Python app as bundle-loader
+			# No framework, use the Tauthon app as bundle-loader
 			BLDSHARED="$LDSHARED "'-bundle_loader $(BUILDTAUTHON)'
-			LDSHARED="$LDSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
-			LDCXXSHARED="$LDCXXSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
+			LDSHARED="$LDSHARED "'-bundle_loader $(BINDIR)/tauthon$(VERSION)$(EXE)'
+			LDCXXSHARED="$LDCXXSHARED "'-bundle_loader $(BINDIR)/tauthon$(VERSION)$(EXE)'
 		fi ;;
 	Darwin/*)
 		# Use -undefined dynamic_lookup whenever possible (10.3 and later).
-		# This allows an extension to be used in any Python
+		# This allows an extension to be used in any Tauthon
 
 		dep_target_major=`echo ${MACOSX_DEPLOYMENT_TARGET} | \
 				sed 's/\([0-9]*\)\.\([0-9]*\).*/\1/'`
@@ -8641,10 +8641,10 @@ then
 				LDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 				LDCXXSHARED="$LDCXXSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 			else
-				# No framework, use the Python app as bundle-loader
+				# No framework, use the Tauthon app as bundle-loader
 				BLDSHARED="$LDSHARED "'-bundle_loader $(BUILDTAUTHON)'
-				LDSHARED="$LDSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
-				LDCXXSHARED="$LDCXXSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
+				LDSHARED="$LDSHARED "'-bundle_loader $(BINDIR)/tauthon$(VERSION)$(EXE)'
+				LDCXXSHARED="$LDCXXSHARED "'-bundle_loader $(BINDIR)/tauthon$(VERSION)$(EXE)'
 			fi
 		else
 			# building for OS X 10.3 and later
@@ -8750,7 +8750,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CCSHARED" >&5
 $as_echo "$CCSHARED" >&6; }
 # LINKFORSHARED are the flags passed to the $(CC) command that links
-# the python executable -- this is only needed for a few systems
+# the tauthon executable -- this is only needed for a few systems
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking LINKFORSHARED" >&5
 $as_echo_n "checking LINKFORSHARED... " >&6; }
 if test -z "$LINKFORSHARED"
@@ -8770,7 +8770,7 @@ then
 		# that dynamically loaded extension modules have access to it.
 		# -prebind is no longer used, because it actually seems to give a
 		# slowdown in stead of a speedup, maybe due to the large number of
-		# dynamic loads Python does.
+		# dynamic loads Tauthon does.
 
 		LINKFORSHARED="$extra_undefs"
 		if test "$enable_framework"
@@ -8828,12 +8828,12 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CFLAGSFORSHARED" >&5
 $as_echo "$CFLAGSFORSHARED" >&6; }
 
-# SHLIBS are libraries (except -lc and -lm) to link to the python shared
+# SHLIBS are libraries (except -lc and -lm) to link to the tauthon shared
 # library (with --enable-shared).
 # For platforms on which shared libraries are not allowed to have unresolved
 # symbols, this must be set to $(LIBS) (expanded by make). We do this even
 # if it is not required, since it creates a dependency of the shared library
-# to LIBS. This, in turn, means that applications linking the shared libpython
+# to LIBS. This, in turn, means that applications linking the shared libtauthon
 # don't need to link LIBS explicitly. The default should be only changed
 # on systems where this approach causes problems.
 
@@ -10415,7 +10415,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_doc_strings" >&5
 $as_echo "$with_doc_strings" >&6; }
 
-# Check for Python-specific malloc support
+# Check for Tauthon-specific malloc support
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-tsc" >&5
 $as_echo_n "checking for --with-tsc... " >&6; }
 
@@ -10438,7 +10438,7 @@ $as_echo "no" >&6; }
 fi
 
 
-# Check for Python-specific malloc support
+# Check for Tauthon-specific malloc support
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-pymalloc" >&5
 $as_echo_n "checking for --with-pymalloc... " >&6; }
 
@@ -10566,7 +10566,7 @@ $as_echo "#define HAVE_DYNAMIC_LOADING 1" >>confdefs.h
 
 fi
 
-# MACHDEP_OBJS can be set to platform-specific object files needed by Python
+# MACHDEP_OBJS can be set to platform-specific object files needed by Tauthon
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking MACHDEP_OBJS" >&5
@@ -11126,7 +11126,7 @@ fi
 
 
 # On Tru64, chflags seems to be present, but calling it will
-# exit Python
+# exit Tauthon
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for chflags" >&5
 $as_echo_n "checking for chflags... " >&6; }
 if ${ac_cv_have_chflags+:} false; then :
@@ -13004,7 +13004,7 @@ $as_echo "#define DOUBLE_IS_BIG_ENDIAN_IEEE754 1" >>confdefs.h
 fi
 
 # Some ARM platforms use a mixed-endian representation for doubles.
-# While Python doesn't currently have full support for these platforms
+# While Tauthon doesn't currently have full support for these platforms
 # (see e.g., issue 1762561), we can at least make sure that float <-> string
 # conversions work.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C doubles are ARM mixed-endian IEEE 754 binary64" >&5
@@ -13371,9 +13371,9 @@ $as_echo "#define HAVE_BROKEN_SEM_GETVALUE 1" >>confdefs.h
 
 fi
 
-# determine what size digit to use for Python's longs
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking digit size for Python's longs" >&5
-$as_echo_n "checking digit size for Python's longs... " >&6; }
+# determine what size digit to use for Tauthon's longs
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking digit size for Tauthon's longs" >&5
+$as_echo_n "checking digit size for Tauthon's longs... " >&6; }
 # Check whether --enable-big-digits was given.
 if test "${enable_big_digits+set}" = set; then :
   enableval=$enable_big_digits; case $enable_big_digits in
@@ -13908,7 +13908,7 @@ $as_echo "#define HAVE_GETC_UNLOCKED 1" >>confdefs.h
 fi
 
 # check where readline lives
-# save the value of LIBS so we don't actually link Python with readline
+# save the value of LIBS so we don't actually link Tauthon with readline
 LIBS_no_readline=$LIBS
 
 # On some systems we need to link readline to a termcap compatible

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1013,7 +1013,7 @@
 /* Define if you want to build an interpreter with many run-time checks. */
 #undef Py_DEBUG
 
-/* Defined if Python is built as a shared library. */
+/* Defined if Tauthon is built as a shared library. */
 #undef Py_ENABLE_SHARED
 
 /* Define as the size of the unicode type. */
@@ -1126,7 +1126,7 @@
 #endif
 
 
-/* Define if you want to use MacPython modules on MacOSX in unix-Python. */
+/* Define if you want to use MacTauthon modules on MacOSX in unix-Tauthon. */
 #undef USE_TOOLBOX_OBJECT_GLUE
 
 /* Define if a va_list is an array of some kind */
@@ -1136,7 +1136,7 @@
 #undef WANT_SIGFPE_HANDLER
 
 /* Define if you want wctype.h functions to be used instead of the one
-   supplied by Python itself. (see Include/unicodectype.h). */
+   supplied by Tauthon itself. (see Include/unicodectype.h). */
 #undef WANT_WCTYPE_FUNCTIONS
 
 /* Define if WINDOW in curses.h offers a field _flags. */
@@ -1157,7 +1157,7 @@
    library plus accessory files). */
 #undef WITH_NEXT_FRAMEWORK
 
-/* Define if you want to compile in Python-specific mallocs */
+/* Define if you want to compile in Tauthon-specific mallocs */
 #undef WITH_PYMALLOC
 
 /* Define if you want to compile in rudimentary thread support */

--- a/setup.py
+++ b/setup.py
@@ -256,11 +256,13 @@ class PyBuildExt(build_ext):
         # those environment variables passed into the setup.py phase.  Here's
         # a small set of useful ones.
         compiler = os.environ.get('CC')
+        # it's important to get CFLAGS from the environment for proper extension PGO support
+        cflags = os.environ.get('CFLAGS')
         args = {}
         # unfortunately, distutils doesn't let us provide separate C and C++
         # compilers
         if compiler is not None:
-            (ccshared,cflags) = sysconfig.get_config_vars('CCSHARED','CFLAGS')
+            (ccshared,) = sysconfig.get_config_vars('CCSHARED')
             args['compiler_so'] = compiler + ' ' + ccshared + ' ' + cflags
         self.compiler.set_executables(**args)
 

--- a/setup.py
+++ b/setup.py
@@ -257,7 +257,7 @@ class PyBuildExt(build_ext):
         # a small set of useful ones.
         compiler = os.environ.get('CC')
         # it's important to get CFLAGS from the environment for proper extension PGO support
-        cflags = os.environ.get('CFLAGS')
+        cflags = os.environ.get('CFLAGS', sysconfig.get_config_vars('CFLAGS')[0])
         args = {}
         # unfortunately, distutils doesn't let us provide separate C and C++
         # compilers


### PR DESCRIPTION
Extensions where not properly compiled with PGO because the CFLAGS were
    not read from the environment in "setup.py". Once that was fixed, gcc
    failed with an internal compiler error (ICE) because the same source file was
    used in 3 different extensions so it was compiled 3 different times in
    the profile generation stage: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85759
    
After introducing the concept of mtime-conditional recompilation to
    distutils, the ICE was avoided.
    
While building the software in a sandbox, on Gentoo, it became obvious
    that the profiling task was accessing system-wide paths it had no
    business accessing. This was also fixed.
    
A couple of regression tests fail randomly when the suite is run in
    parallel, so we work around that by excluding them from the profiling
    task.
    
EXTRATESTOPTS is now used inside PROFILE_TASK, to allow for custom
    arguments (like "-jN" to run N jobs in parallel).
    
We no longer let the profiling task fail silently.