### PR TITLE
Back-port of fix for issue 34113, lltrace segv

### DIFF
--- a/Lib/test/test_lltrace.py
+++ b/Lib/test/test_lltrace.py
@@ -1,0 +1,24 @@
+import os
+import textwrap
+import unittest
+from test import support
+from test.support.script_helper import assert_python_ok
+class TestLLTrace(unittest.TestCase):
+    def test_lltrace_does_not_crash_on_subscript_operator(self):
+        # If this test fails, it will reproduce a crash reported as
+        # bpo-34113. The crash happened at the command line console of
+        # debug Python builds with __ltrace__ enabled (only possible in console),
+        # when the interal Python stack was negatively adjusted
+        with open(support.TESTFN, 'w') as fd:
+            self.addCleanup(os.unlink, support.TESTFN)
+            fd.write(textwrap.dedent("""\
+            import code
+            console = code.InteractiveConsole()
+            console.push('__ltrace__ = 1')
+            console.push('a = [1, 2, 3]')
+            console.push('a[0] = 1')
+            print('unreachable if bug exists')
+            """))
+            assert_python_ok(support.TESTFN)
+if __name__ == "__main__":
+    unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-28-10-34-00.bpo-34113.eZ5FWV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-28-10-34-00.bpo-34113.eZ5FWV.rst
@@ -1,0 +1,2 @@
+Fixed crash on debug builds when opcode stack was adjusted with negative
+numbers. Patch by Constantin Petrisor.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -945,16 +945,28 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                           assert(STACK_LEVEL() <= co->co_stacksize); }
 #define POP()           ((void)(lltrace && prtrace(TOP(), "pop")), \
                          BASIC_POP())
-#define STACKADJ(n)     { (void)(BASIC_STACKADJ(n), \
+
+#define STACK_GROW(n)   { \
+                          assert((n) >= 0); \
+                          (void)(BASIC_STACKADJ(n), \
                           lltrace && prtrace(TOP(), "stackadj")); \
-                          assert(STACK_LEVEL() <= co->co_stacksize); }
+                          assert(STACK_LEVEL() <= co->co_stacksize); \
+                        }
+#define STACK_SHRINK(n) { \
+                          assert((n) >= 0); \
+                          assert((n) <= STACK_LEVEL()); \
+                          (void)(lltrace && prtrace(TOP(), "stackadj")); \
+                          (void)(BASIC_STACKADJ(-(n))); \
+                        }
+
 #define EXT_POP(STACK_POINTER) ((void)(lltrace && \
                                 prtrace((STACK_POINTER)[-1], "ext_pop")), \
                                 *--(STACK_POINTER))
 #else
 #define PUSH(v)                BASIC_PUSH(v)
 #define POP()                  BASIC_POP()
-#define STACKADJ(n)            BASIC_STACKADJ(n)
+#define STACK_GROW(n)          BASIC_STACKADJ(n)
+#define STACK_SHRINK(n)        BASIC_STACKADJ(-(n))
 #define EXT_POP(STACK_POINTER) (*--(STACK_POINTER))
 #endif
 
@@ -1278,7 +1290,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
         }
 
         TARGET_NOARG(ROT_FOUR)
-         {
+        {
             u = TOP();
             v = SECOND();
             w = THIRD();
@@ -1307,7 +1319,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                 Py_INCREF(x);
                 w = SECOND();
                 Py_INCREF(w);
-                STACKADJ(2);
+                STACK_GROW(2);
                 SET_TOP(x);
                 SET_SECOND(w);
                 FAST_DISPATCH();
@@ -1318,7 +1330,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                 Py_INCREF(w);
                 v = THIRD();
                 Py_INCREF(v);
-                STACKADJ(3);
+                STACK_GROW(3);
                 SET_TOP(x);
                 SET_SECOND(w);
                 SET_THIRD(v);
@@ -1366,7 +1378,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                 err = 0;
                 DISPATCH();
             }
-            STACKADJ(-1);
+            STACK_SHRINK(1);
             break;
         }
 
@@ -1861,7 +1873,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
         }
 
 
-     
+
         TARGET_WITH_IMPL_NOARG(SLICE, _slice)
         TARGET_WITH_IMPL_NOARG(SLICE_1, _slice)
         TARGET_WITH_IMPL_NOARG(SLICE_2, _slice)
@@ -1942,7 +1954,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
             w = TOP();
             v = SECOND();
             u = THIRD();
-            STACKADJ(-3);
+            STACK_SHRINK(3);
             /* v[w] = u */
             err = PyObject_SetItem(v, w, u);
             Py_DECREF(u);
@@ -1956,7 +1968,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
         {
             w = TOP();
             v = SECOND();
-            STACKADJ(-2);
+            STACK_SHRINK(2);
             /* del v[w] */
             err = PyObject_DelItem(v, w);
             Py_DECREF(v);
@@ -2290,7 +2302,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
             w = TOP();
             v = SECOND();
             u = THIRD();
-            STACKADJ(-3);
+            STACK_SHRINK(3);
             READ_TIMESTAMP(intr0);
             err = exec_statement(f, u, v, w);
             READ_TIMESTAMP(intr1);
@@ -2433,7 +2445,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                 }
             } else if (unpack_iterable(v, oparg,
                                        stack_pointer + oparg)) {
-                STACKADJ(oparg);
+                STACK_GROW(oparg);
             } else {
                 /* unpack_iterable() raised an exception */
                 why = WHY_EXCEPTION;
@@ -2448,7 +2460,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
             w = GETITEM(names, oparg);
             v = TOP();
             u = SECOND();
-            STACKADJ(-2);
+            STACK_SHRINK(2);
             err = PyObject_SetAttr(v, w, u); /* v.w = u */
             Py_DECREF(v);
             Py_DECREF(u);
@@ -2682,7 +2694,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                         err = PySet_Add(x, w);
                     Py_DECREF(w);
                 }
-                STACKADJ(-oparg);
+                STACK_SHRINK(oparg);
                 if (err != 0) {
                     Py_DECREF(x);
                     break;
@@ -2706,7 +2718,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
             w = TOP();     /* key */
             u = SECOND();  /* value */
             v = THIRD();   /* dict */
-            STACKADJ(-2);
+            STACK_SHRINK(2);
             assert (PyDict_CheckExact(v));
             err = PyDict_SetItem(v, w, u);  /* v[w] = u */
             Py_DECREF(u);
@@ -2719,7 +2731,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
         {
             w = TOP();     /* key */
             u = SECOND();  /* value */
-            STACKADJ(-2);
+            STACK_SHRINK(2);
             v = stack_pointer[-oparg];  /* dict */
             assert (PyDict_CheckExact(v));
             err = PyDict_SetItem(v, w, u);  /* v[w] = u */
@@ -2924,7 +2936,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
         {
             w = TOP();
             if (w == Py_True) {
-                STACKADJ(-1);
+                STACK_SHRINK(1);
                 Py_DECREF(w);
                 FAST_DISPATCH();
             }
@@ -2934,7 +2946,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
             }
             err = PyObject_IsTrue(w);
             if (err > 0) {
-                STACKADJ(-1);
+                STACK_SHRINK(1);
                 Py_DECREF(w);
                 err = 0;
             }
@@ -2949,7 +2961,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
         {
             w = TOP();
             if (w == Py_False) {
-                STACKADJ(-1);
+                STACK_SHRINK(1);
                 Py_DECREF(w);
                 FAST_DISPATCH();
             }
@@ -2963,7 +2975,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                 JUMPTO(oparg);
             }
             else if (err == 0) {
-                STACKADJ(-1);
+                STACK_SHRINK(1);
                 Py_DECREF(w);
             }
             else
@@ -3000,7 +3012,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                 PREDICT(FOR_ITER);
                 DISPATCH();
             }
-            STACKADJ(-1);
+            STACK_SHRINK(1);
             break;
         }
 
@@ -3243,7 +3255,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                 /* There was an exception and a true return */
                 v = SECOND();
                 w = THIRD();
-                STACKADJ(-2);
+                STACK_SHRINK(2);
                 Py_INCREF(Py_None);
                 SET_TOP(Py_None);
                 Py_DECREF(u);


### PR DESCRIPTION
    https://bugs.python.org/issue34113
which exists in 2.7, but will only be fixed in 3.7