### PR TITLE
Fix SSL regression test failure on non-UTF8 filesystems

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1000,8 +1000,16 @@ class ContextTests(unittest.TestCase):
         self.assertEqual(cm.exception.errno, errno.ENOENT)
         with self.assertRaises(ssl.SSLError) as cm:
             ctx.load_dh_params(CERTFILE)
+
         with support.temp_dir() as d:
             fname = os.path.join(d, u'dhpäräm.pem')
+            fsencoding = sys.getfilesystemencoding() or \
+                sys.getdefaultencoding()
+            try:
+                fname = fname.encode(fsencoding)
+            except:
+                raise unittest.SkipTest("only NT+ and systems with "
+                    "Unicode-friendly filesystem encoding")
             shutil.copy(DHFILE, fname)
             ctx.load_dh_params(fname)
 


### PR DESCRIPTION
Use logic found elsewhere in tests to detect and skip tests which
require (in this case) UTF8 filenames in the filesystem, when
the filesystem does not support them.