### PR TITLE
Travis CI: Sudo and Trusty are no longer needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: c
-dist: trusty
-sudo: false
 group: beta
 
 # To cache doc-building dependencies and C compiler output.


### PR DESCRIPTION
Travis has fully deprecated the __sudo:__ tag and Trusty is not longer the default Travis distro because it has reach the end of normal support.