### PR TITLE
CVE-2019-9948: Avoid file reading as disallowing the unnecessary URL scheme in urllib.urlopen().

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1023,6 +1023,13 @@ class URLopener_Tests(unittest.TestCase):
             "spam://c:|windows%/:=&?~#+!$,;'@()*[]|/path/"),
             "//c:|windows%/:=&?~#+!$,;'@()*[]|/path/")
 
+    def test_local_file_open(self):
+        class DummyURLopener(urllib.URLopener):
+            def open_local_file(self, url):
+                return url
+        for url in ('local_file://example', 'local-file://example'):
+            self.assertRaises(IOError, DummyURLopener().open, url)
+            self.assertRaises(IOError, urllib.urlopen, url)
 
 # Just commented them out.
 # Can't really tell why keep failing in windows and sparc.

--- a/Lib/urllib.py
+++ b/Lib/urllib.py
@@ -203,7 +203,9 @@ class URLopener:
         name = 'open_' + urltype
         self.type = urltype
         name = name.replace('-', '_')
-        if not hasattr(self, name):
+
+        # bpo-35907: disallow the file reading with the type not allowed
+        if not hasattr(self, name) or name == 'open_local_file':
             if proxy:
                 return self.open_unknown_proxy(proxy, fullurl, data)
             else:

--- a/Misc/NEWS.d/next/Library/2019-02-13-17-21-10.bpo-35907.ckk2zg.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-13-17-21-10.bpo-35907.ckk2zg.rst
@@ -1,0 +1,1 @@
+CVE-2019-9948: Avoid file reading as disallowing the unnecessary URL scheme in urllib.urlopen


### PR DESCRIPTION
Another CVE similar to PR #118.

This was cherry-picked from CPython's b15bde8058e821b383d81fcae68b335a752083ca.

DO NOT MERGE, as this will come for free the next time Tauthon is re-sync'd with v2.7.16.