### PR TITLE
Added some more Microsoft compilers to Lib/distutils and a fix to adjust the majorVersion for VS2015

### DIFF
--- a/Lib/distutils/cygwinccompiler.py
+++ b/Lib/distutils/cygwinccompiler.py
@@ -75,6 +75,18 @@ def get_msvcr():
         elif msc_ver == '1500':
             # VS2008 / MSVC 9.0
             return ['msvcr90']
+        elif msc_ver == '1600':
+            # VS2010 / MSVC 10.0
+            return ['msvcr100']
+        elif msc_ver == '1700':
+            # VS2012 / MSVC 11.0
+            return ['msvcr110']
+        elif msc_ver == '1800':
+            # VS2013 / MSVC 12.0
+            return ['msvcr120']
+        elif msc_ver == '1900':
+            # VS2015 / MSVC 14.0
+            return ['vcruntime140']
         else:
             raise ValueError("Unknown MS Compiler version %s " % msc_ver)
 

--- a/Lib/distutils/msvc9compiler.py
+++ b/Lib/distutils/msvc9compiler.py
@@ -183,6 +183,10 @@ def get_build_version():
     s, rest = sys.version[i:].split(" ", 1)
     majorVersion = int(s[:-2]) - 6
     minorVersion = int(s[2:3]) / 10.0
+
+    # There is no majorVersion of 13 (VS2013 == 1800, and VS2015 == 1900)
+    if majorVersion == 13: majorVersion = 14
+
     # I don't think paths are affected by minor version in version 6
     if majorVersion == 6:
         minorVersion = 0

--- a/Lib/distutils/msvccompiler.py
+++ b/Lib/distutils/msvccompiler.py
@@ -165,6 +165,10 @@ def get_build_version():
     s, rest = sys.version[i:].split(" ", 1)
     majorVersion = int(s[:-2]) - 6
     minorVersion = int(s[2:3]) / 10.0
+
+    # There is no majorVersion of 13 (VS2013 == 1800, and VS2015 == 1900)
+    if majorVersion == 13: majorVersion = 14
+
     # I don't think paths are affected by minor version in version 6
     if majorVersion == 6:
         minorVersion = 0

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -160,6 +160,10 @@ time_clock(PyObject *self, PyObject *unused)
 #endif /* HAVE_CLOCK */
 
 #if defined(MS_WINDOWS) && !defined(__BORLANDC__)
+#include <time.h>
+#define timezone _timezone
+#define daylight _daylight
+#define tzname _tzname
 /* Due to Mark Hammond and Tim Peters */
 static PyObject *
 time_clock(PyObject *self, PyObject *unused)


### PR DESCRIPTION
As per https://bugs.python.org/issue35172:

Distutils makes a few incorrect assumptions that prevent it from supporting the newer Microsoft-y C compilers. This patch fixes it up till MSVC 14.0. There are 2 assumptions that are made by distutils and they are as follows.

The first one is that MSVC's versions scale linearly (subtracting 6). This assumption breaks when encountering major version 13.0 as VS2013 (12.0) uses 1800 and VS2015 (14.0) uses 1900 and so the calculation for version 13.0 does not actually exist. This was fixed in the patch for both msvc9compiler.py and msvccompiler.py by skipping the major version 13.

The second assumption is in the get_msvcr() function in cygwinccompiler.py and is responsible for identifying the CRT name. The newer versions of MSVC aren't listed, so these were added in the patch. However, for version 1900 (MSVC 14.0) the crt is now named "vcruntime140" which was included. It might be better to to make this table-based if there is long-term interest in supporting these other compilers.