### PR TITLE
Adds support for specifying the Platform Toolset to PCbuild/build.bat

### DIFF
--- a/PCbuild/build.bat
+++ b/PCbuild/build.bat
@@ -45,6 +45,9 @@ echo.  -t Build ^| Rebuild ^| Clean ^| CleanAll
 echo.     Set the target manually
 echo.  --pgo-job  The job to use for PGO training; implies --pgo
 echo.             (default: "-m test.regrtest --pgo")
+echo.  --platform-toolset v90 ^| v110 ^| v120 ^| v140
+echo.                     Specify the platform toolset to use
+echo.                     (default: v90)
 exit /b 127
 
 :Run
@@ -58,6 +61,7 @@ set verbose=-nologo -v:m
 set kill=
 set do_pgo=
 set pgo_job=-m test.regrtest --pgo
+set PlatformToolset=v90
 
 :CheckOpts
 if "%~1"=="-h" goto Usage
@@ -79,6 +83,7 @@ if "%~1"=="-e" (set IncludeExternals=true) & shift & goto CheckOpts
 if "%~1"=="--no-ssl" (set IncludeSSL=false) & shift & goto CheckOpts
 if "%~1"=="--no-tkinter" (set IncludeTkinter=false) & shift & goto CheckOpts
 if "%~1"=="--no-bsddb" (set IncludeBsddb=false) & shift & goto CheckOpts
+if "%~1"=="--platform-toolset" (set PlatformToolset=%2) & shift & shift & goto CheckOpts
 
 if "%IncludeExternals%"=="" set IncludeExternals=false
 if "%IncludeSSL%"=="" set IncludeSSL=true
@@ -136,8 +141,9 @@ echo on
 %MSBUILD% "%dir%pcbuild.proj" -t:%target% %parallel% %verbose%^
  -p:Configuration=%conf% -p:Platform=%platf%^
  -p:IncludeExternals=%IncludeExternals%^
- -p:IncludeSSL=%IncludeSSL% -p:IncludeTkinter=%IncludeTkinter%^
- -p:IncludeBsddb=%IncludeBsddb% %GITProperty%^
+ -p:IncludeSSL=%IncludeSSL% -p:IncludeTkinter=%IncludeTkinter% -p:IncludeBsddb=%IncludeBsddb%^
+ -p:PlatformToolset=%PlatformToolset%^
+ %GITProperty%^
  %1 %2 %3 %4 %5 %6 %7 %8 %9
 
 @echo off

--- a/PCbuild/build.bat
+++ b/PCbuild/build.bat
@@ -8,7 +8,7 @@ echo.version(s) of Microsoft Visual Studio to be installed (see readme.txt).
 echo.
 echo.After the flags recognized by this script, up to 9 arguments to be passed
 echo.directly to MSBuild may be passed.  If the argument contains an '=', the
-echo.entire argument must be quoted (e.g. `%~nx0 "/p:PlatformToolset=v100"`).
+echo.entire argument must be quoted (e.g. `%~nx0 "-p:PlatformToolset=v100"`).
 echo.Alternatively you can put extra flags for MSBuild in a file named 
 echo.`msbuild.rsp` in the `PCbuild` directory, one flag per line. This file
 echo.will be picked automatically by MSBuild. Flags put in this file does not
@@ -54,7 +54,7 @@ set conf=Release
 set target=Build
 set dir=%~dp0
 set parallel=
-set verbose=/nologo /v:m
+set verbose=-nologo -v:m
 set kill=
 set do_pgo=
 set pgo_job=-m test.regrtest --pgo
@@ -66,9 +66,9 @@ if "%~1"=="-p" (set platf=%2) & shift & shift & goto CheckOpts
 if "%~1"=="-r" (set target=Rebuild) & shift & goto CheckOpts
 if "%~1"=="-t" (set target=%2) & shift & shift & goto CheckOpts
 if "%~1"=="-d" (set conf=Debug) & shift & goto CheckOpts
-if "%~1"=="-m" (set parallel=/m) & shift & goto CheckOpts
+if "%~1"=="-m" (set parallel=-m) & shift & goto CheckOpts
 if "%~1"=="-M" (set parallel=) & shift & goto CheckOpts
-if "%~1"=="-v" (set verbose=/v:n) & shift & goto CheckOpts
+if "%~1"=="-v" (set verbose=-v:n) & shift & goto CheckOpts
 if "%~1"=="-k" (set kill=true) & shift & goto CheckOpts
 if "%~1"=="--pgo" (set do_pgo=true) & shift & goto CheckOpts
 if "%~1"=="--pgo-job" (set do_pgo=true) & (set pgo_job=%~2) & shift & shift & goto CheckOpts
@@ -97,7 +97,7 @@ if "%do_pgo%" EQU "true" if "%platf%" EQU "x64" (
 )
 
 if "%GIT%" EQU "" set GIT=git
-if exist "%GIT%" set GITProperty=/p:GIT="%GIT%"
+if exist "%GIT%" set GITProperty=-p:GIT="%GIT%"
 
 rem Setup the environment
 call "%dir%find_msbuild.bat" %MSBUILD%
@@ -121,9 +121,9 @@ goto Build
 
 :Kill
 echo on
-%MSBUILD% "%dir%\pythoncore.vcxproj" /t:KillPython %verbose%^
- /p:Configuration=%conf% /p:Platform=%platf%^
- /p:KillPython=true
+%MSBUILD% "%dir%\pythoncore.vcxproj" -t:KillPython %verbose%^
+ -p:Configuration=%conf% -p:Platform=%platf%^
+ -p:KillPython=true
 
 @echo off
 goto :eof
@@ -133,11 +133,11 @@ rem Call on MSBuild to do the work, echo the command.
 rem Passing %1-9 is not the preferred option, but argument parsing in
 rem batch is, shall we say, "lackluster"
 echo on
-%MSBUILD% "%dir%pcbuild.proj" /t:%target% %parallel% %verbose%^
- /p:Configuration=%conf% /p:Platform=%platf%^
- /p:IncludeExternals=%IncludeExternals%^
- /p:IncludeSSL=%IncludeSSL% /p:IncludeTkinter=%IncludeTkinter%^
- /p:IncludeBsddb=%IncludeBsddb% %GITProperty%^
+%MSBUILD% "%dir%pcbuild.proj" -t:%target% %parallel% %verbose%^
+ -p:Configuration=%conf% -p:Platform=%platf%^
+ -p:IncludeExternals=%IncludeExternals%^
+ -p:IncludeSSL=%IncludeSSL% -p:IncludeTkinter=%IncludeTkinter%^
+ -p:IncludeBsddb=%IncludeBsddb% %GITProperty%^
  %1 %2 %3 %4 %5 %6 %7 %8 %9
 
 @echo off

--- a/PCbuild/env.bat
+++ b/PCbuild/env.bat
@@ -14,10 +14,10 @@ echo.
 rem Set up the v90 tools first.  This is mostly needed to allow PGInstrument
 rem builds to find the PGO DLL.  Do it first so the newer MSBuild is found
 rem before the one from v90 (vcvarsall.bat prepends to PATH).
-call "%VS90COMNTOOLS%..\..\VC\vcvarsall.bat" %*
 
 set VSTOOLS=%VS140COMNTOOLS%
 if "%VSTOOLS%"=="" set VSTOOLS=%VS120COMNTOOLS%
 if "%VSTOOLS%"=="" set VSTOOLS=%VS110COMNTOOLS%
 if "%VSTOOLS%"=="" set VSTOOLS=%VS100COMNTOOLS%
+if "%VSTOOLS%"=="" set VSTOOLS=%VS90COMNTOOLS%
 call "%VSTOOLS%..\..\VC\vcvarsall.bat" %*


### PR DESCRIPTION
This adds a new parameter to `PCbuild/build.bat` which exposes setting the Platform Toolset  property for `msbuild` to link with. It appears you can simply set the "-property" parameter already, but this exposes it so that it's a hella more obvious. Originally, python/tauthon was using `v90` so the default value for this property was also set to the same value. This way it should work the same way it did originally prior to the addition.

I also had to modify `PCbuild/env.bat` a little bit. It turns out that this script already attempted to determine the path to `vcvarsall.bat` using `$VS90COMNTOOLS`. It would run `vcvarsall.bat` from Visual Studio 9.0 first, and then include any others that it could so that way Visual Studio 9.0 was mandatory. This removes that mandatory-ness since we're using the newer version of Visual Studio anyways.

I added the parameter as a long-parameter, "--platform-toolset", so you can use it like:
```
$ PCbuild/build.bat --platform-toolset v140
```

With regards to `appveyor.yml`, I think one would just need to add `--platform-toolset` and make sure the image has the target version of Visual Studio on it. I'm not too familiar with appveyor, and as such I'm not sure what they have installed by default.