### PR TITLE
Support for Python3's time.monotonic()

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -79,6 +79,7 @@
 #error "PYMALLOC_DEBUG requires WITH_PYMALLOC"
 #endif
 #include "pymath.h"
+#include "pytime.h"
 #include "pymem.h"
 
 #include "object.h"

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -59,6 +59,7 @@
 #include <assert.h>
 
 #include "pyport.h"
+#include "pymacro.h"
 
 /* pyconfig.h or pyport.h may or may not define DL_IMPORT */
 #ifndef DL_IMPORT	/* declarations for DLL import/export */

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -1,0 +1,100 @@
+#ifndef Py_PYMACRO_H
+#define Py_PYMACRO_H
+
+/* Minimum value between x and y */
+#define Py_MIN(x, y) (((x) > (y)) ? (y) : (x))
+
+/* Maximum value between x and y */
+#define Py_MAX(x, y) (((x) > (y)) ? (x) : (y))
+
+/* Absolute value of the number x */
+#define Py_ABS(x) ((x) < 0 ? -(x) : (x))
+
+#define _Py_XSTRINGIFY(x) #x
+
+/* Convert the argument to a string. For example, Py_STRINGIFY(123) is replaced
+   with "123" by the preprocessor. Defines are also replaced by their value.
+   For example Py_STRINGIFY(__LINE__) is replaced by the line number, not
+   by "__LINE__". */
+#define Py_STRINGIFY(x) _Py_XSTRINGIFY(x)
+
+/* Get the size of a structure member in bytes */
+#define Py_MEMBER_SIZE(type, member) sizeof(((type *)0)->member)
+
+/* Argument must be a char or an int in [-128, 127] or [0, 255]. */
+#define Py_CHARMASK(c) ((unsigned char)((c) & 0xff))
+
+/* Assert a build-time dependency, as an expression.
+
+   Your compile will fail if the condition isn't true, or can't be evaluated
+   by the compiler. This can be used in an expression: its value is 0.
+
+   Example:
+
+   #define foo_to_char(foo)  \
+       ((char *)(foo)        \
+        + Py_BUILD_ASSERT_EXPR(offsetof(struct foo, string) == 0))
+
+   Written by Rusty Russell, public domain, http://ccodearchive.net/ */
+#define Py_BUILD_ASSERT_EXPR(cond) \
+    (sizeof(char [1 - 2*!(cond)]) - 1)
+
+#define Py_BUILD_ASSERT(cond)  do {         \
+        (void)Py_BUILD_ASSERT_EXPR(cond);   \
+    } while(0)
+
+/* Get the number of elements in a visible array
+
+   This does not work on pointers, or arrays declared as [], or function
+   parameters. With correct compiler support, such usage will cause a build
+   error (see Py_BUILD_ASSERT_EXPR).
+
+   Written by Rusty Russell, public domain, http://ccodearchive.net/
+
+   Requires at GCC 3.1+ */
+#if (defined(__GNUC__) && !defined(__STRICT_ANSI__) && \
+    (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ >= 4)))
+/* Two gcc extensions.
+   &a[0] degrades to a pointer: a different type from an array */
+#define Py_ARRAY_LENGTH(array) \
+    (sizeof(array) / sizeof((array)[0]) \
+     + Py_BUILD_ASSERT_EXPR(!__builtin_types_compatible_p(typeof(array), \
+                                                          typeof(&(array)[0]))))
+#else
+#define Py_ARRAY_LENGTH(array) \
+    (sizeof(array) / sizeof((array)[0]))
+#endif
+
+
+/* Define macros for inline documentation. */
+#define PyDoc_VAR(name) static char name[]
+#define PyDoc_STRVAR(name,str) PyDoc_VAR(name) = PyDoc_STR(str)
+#ifdef WITH_DOC_STRINGS
+#define PyDoc_STR(str) str
+#else
+#define PyDoc_STR(str) ""
+#endif
+
+/* Below "a" is a power of 2. */
+/* Round down size "n" to be a multiple of "a". */
+#define _Py_SIZE_ROUND_DOWN(n, a) ((size_t)(n) & ~(size_t)((a) - 1))
+/* Round up size "n" to be a multiple of "a". */
+#define _Py_SIZE_ROUND_UP(n, a) (((size_t)(n) + \
+        (size_t)((a) - 1)) & ~(size_t)((a) - 1))
+/* Round pointer "p" down to the closest "a"-aligned address <= "p". */
+#define _Py_ALIGN_DOWN(p, a) ((void *)((uintptr_t)(p) & ~(uintptr_t)((a) - 1)))
+/* Round pointer "p" up to the closest "a"-aligned address >= "p". */
+#define _Py_ALIGN_UP(p, a) ((void *)(((uintptr_t)(p) + \
+        (uintptr_t)((a) - 1)) & ~(uintptr_t)((a) - 1)))
+/* Check if pointer "p" is aligned to "a"-bytes boundary. */
+#define _Py_IS_ALIGNED(p, a) (!((uintptr_t)(p) & (uintptr_t)((a) - 1)))
+
+#ifdef __GNUC__
+#define Py_UNUSED(name) _unused_ ## name __attribute__((unused))
+#else
+#define Py_UNUSED(name) _unused_ ## name
+#endif
+
+#define Py_UNREACHABLE() abort()
+
+#endif /* Py_PYMACRO_H */

--- a/Include/pymath.h
+++ b/Include/pymath.h
@@ -215,4 +215,16 @@ PyAPI_FUNC(void) _Py_set_387controlword(unsigned short);
 					 (X) == -Py_HUGE_VAL))
 #endif
 
+/* Return whether integral type *type* is signed or not. */
+#define _Py_IntegralTypeSigned(type) ((type)(-1) < 0)
+/* Return the maximum value of integral type *type*. */
+#define _Py_IntegralTypeMax(type) ((_Py_IntegralTypeSigned(type)) ? (((((type)1 << (sizeof(type)*CHAR_BIT - 2)) - 1) << 1) + 1) : ~(type)0)
+/* Return the minimum value of integral type *type*. */
+#define _Py_IntegralTypeMin(type) ((_Py_IntegralTypeSigned(type)) ? -_Py_IntegralTypeMax(type) - 1 : 0)
+/* Check whether *v* is in the range of integral type *type*. This is most
+ * useful if *v* is floating-point, since demoting a floating-point *v* to an
+ * integral type that cannot represent *v*'s integral part is undefined
+ * behavior. */
+#define _Py_InIntegralTypeRange(type, v) (_Py_IntegralTypeMin(type) <= v && v <= _Py_IntegralTypeMax(type))
+
 #endif /* Py_PYMATH_H */

--- a/Include/pytime.h
+++ b/Include/pytime.h
@@ -1,0 +1,255 @@
+#ifndef Py_LIMITED_API
+#ifndef Py_PYTIME_H
+#define Py_PYTIME_H
+
+#include "pyconfig.h" /* include for defines */
+#include "object.h"
+
+/**************************************************************************
+Symbols and macros to supply platform-independent interfaces to time related
+functions and constants
+**************************************************************************/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* _PyTime_t: Python timestamp with subsecond precision. It can be used to
+   store a duration, and so indirectly a date (related to another date, like
+   UNIX epoch). */
+typedef int64_t _PyTime_t;
+#define _PyTime_MIN PY_LLONG_MIN
+#define _PyTime_MAX PY_LLONG_MAX
+
+typedef enum {
+    /* Round towards minus infinity (-inf).
+       For example, used to read a clock. */
+    _PyTime_ROUND_FLOOR=0,
+    /* Round towards infinity (+inf).
+       For example, used for timeout to wait "at least" N seconds. */
+    _PyTime_ROUND_CEILING=1,
+    /* Round to nearest with ties going to nearest even integer.
+       For example, used to round from a Python float. */
+    _PyTime_ROUND_HALF_EVEN=2,
+    /* Round away from zero
+       For example, used for timeout. _PyTime_ROUND_CEILING rounds
+       -1e-9 to 0 milliseconds which causes bpo-31786 issue.
+       _PyTime_ROUND_UP rounds -1e-9 to -1 millisecond which keeps
+       the timeout sign as expected. select.poll(timeout) must block
+       for negative values." */
+    _PyTime_ROUND_UP=3,
+    /* _PyTime_ROUND_TIMEOUT (an alias for _PyTime_ROUND_UP) should be
+       used for timeouts. */
+    _PyTime_ROUND_TIMEOUT = _PyTime_ROUND_UP
+} _PyTime_round_t;
+
+
+/* Convert a time_t to a PyLong. */
+PyAPI_FUNC(PyObject *) _PyLong_FromTime_t(
+    time_t sec);
+
+/* Convert a PyLong to a time_t. */
+PyAPI_FUNC(time_t) _PyLong_AsTime_t(
+    PyObject *obj);
+
+/* Convert a number of seconds, int or float, to time_t. */
+PyAPI_FUNC(int) _PyTime_ObjectToTime_t(
+    PyObject *obj,
+    time_t *sec,
+    _PyTime_round_t);
+
+/* Convert a number of seconds, int or float, to a timeval structure.
+   usec is in the range [0; 999999] and rounded towards zero.
+   For example, -1.2 is converted to (-2, 800000). */
+PyAPI_FUNC(int) _PyTime_ObjectToTimeval(
+    PyObject *obj,
+    time_t *sec,
+    long *usec,
+    _PyTime_round_t);
+
+/* Convert a number of seconds, int or float, to a timespec structure.
+   nsec is in the range [0; 999999999] and rounded towards zero.
+   For example, -1.2 is converted to (-2, 800000000). */
+PyAPI_FUNC(int) _PyTime_ObjectToTimespec(
+    PyObject *obj,
+    time_t *sec,
+    long *nsec,
+    _PyTime_round_t);
+
+
+/* Create a timestamp from a number of seconds. */
+PyAPI_FUNC(_PyTime_t) _PyTime_FromSeconds(int seconds);
+
+/* Macro to create a timestamp from a number of seconds, no integer overflow.
+   Only use the macro for small values, prefer _PyTime_FromSeconds(). */
+#define _PYTIME_FROMSECONDS(seconds) \
+            ((_PyTime_t)(seconds) * (1000 * 1000 * 1000))
+
+/* Create a timestamp from a number of nanoseconds. */
+PyAPI_FUNC(_PyTime_t) _PyTime_FromNanoseconds(_PyTime_t ns);
+
+/* Create a timestamp from nanoseconds (Python int). */
+PyAPI_FUNC(int) _PyTime_FromNanosecondsObject(_PyTime_t *t,
+    PyObject *obj);
+
+/* Convert a number of seconds (Python float or int) to a timetamp.
+   Raise an exception and return -1 on error, return 0 on success. */
+PyAPI_FUNC(int) _PyTime_FromSecondsObject(_PyTime_t *t,
+    PyObject *obj,
+    _PyTime_round_t round);
+
+/* Convert a number of milliseconds (Python float or int, 10^-3) to a timetamp.
+   Raise an exception and return -1 on error, return 0 on success. */
+PyAPI_FUNC(int) _PyTime_FromMillisecondsObject(_PyTime_t *t,
+    PyObject *obj,
+    _PyTime_round_t round);
+
+/* Convert a timestamp to a number of seconds as a C double. */
+PyAPI_FUNC(double) _PyTime_AsSecondsDouble(_PyTime_t t);
+
+/* Convert timestamp to a number of milliseconds (10^-3 seconds). */
+PyAPI_FUNC(_PyTime_t) _PyTime_AsMilliseconds(_PyTime_t t,
+    _PyTime_round_t round);
+
+/* Convert timestamp to a number of microseconds (10^-6 seconds). */
+PyAPI_FUNC(_PyTime_t) _PyTime_AsMicroseconds(_PyTime_t t,
+    _PyTime_round_t round);
+
+/* Convert timestamp to a number of nanoseconds (10^-9 seconds) as a Python int
+   object. */
+PyAPI_FUNC(PyObject *) _PyTime_AsNanosecondsObject(_PyTime_t t);
+
+/* Create a timestamp from a timeval structure.
+   Raise an exception and return -1 on overflow, return 0 on success. */
+PyAPI_FUNC(int) _PyTime_FromTimeval(_PyTime_t *tp, struct timeval *tv);
+
+/* Convert a timestamp to a timeval structure (microsecond resolution).
+   tv_usec is always positive.
+   Raise an exception and return -1 if the conversion overflowed,
+   return 0 on success. */
+PyAPI_FUNC(int) _PyTime_AsTimeval(_PyTime_t t,
+    struct timeval *tv,
+    _PyTime_round_t round);
+
+/* Similar to _PyTime_AsTimeval(), but don't raise an exception on error. */
+PyAPI_FUNC(int) _PyTime_AsTimeval_noraise(_PyTime_t t,
+    struct timeval *tv,
+    _PyTime_round_t round);
+
+/* Convert a timestamp to a number of seconds (secs) and microseconds (us).
+   us is always positive. This function is similar to _PyTime_AsTimeval()
+   except that secs is always a time_t type, whereas the timeval structure
+   uses a C long for tv_sec on Windows.
+   Raise an exception and return -1 if the conversion overflowed,
+   return 0 on success. */
+PyAPI_FUNC(int) _PyTime_AsTimevalTime_t(
+    _PyTime_t t,
+    time_t *secs,
+    int *us,
+    _PyTime_round_t round);
+
+#if defined(HAVE_CLOCK_GETTIME) || defined(HAVE_KQUEUE)
+/* Create a timestamp from a timespec structure.
+   Raise an exception and return -1 on overflow, return 0 on success. */
+PyAPI_FUNC(int) _PyTime_FromTimespec(_PyTime_t *tp, struct timespec *ts);
+
+/* Convert a timestamp to a timespec structure (nanosecond resolution).
+   tv_nsec is always positive.
+   Raise an exception and return -1 on error, return 0 on success. */
+PyAPI_FUNC(int) _PyTime_AsTimespec(_PyTime_t t, struct timespec *ts);
+#endif
+
+/* Compute ticks * mul / div.
+   The caller must ensure that ((div - 1) * mul) cannot overflow. */
+PyAPI_FUNC(_PyTime_t) _PyTime_MulDiv(_PyTime_t ticks,
+    _PyTime_t mul,
+    _PyTime_t div);
+
+/* Get the current time from the system clock.
+
+   The function cannot fail. _PyTime_Init() ensures that the system clock
+   works. */
+PyAPI_FUNC(_PyTime_t) _PyTime_GetSystemClock(void);
+
+/* Get the time of a monotonic clock, i.e. a clock that cannot go backwards.
+   The clock is not affected by system clock updates. The reference point of
+   the returned value is undefined, so that only the difference between the
+   results of consecutive calls is valid.
+
+   The function cannot fail. _PyTime_Init() ensures that a monotonic clock
+   is available and works. */
+PyAPI_FUNC(_PyTime_t) _PyTime_GetMonotonicClock(void);
+
+
+/* Structure used by time.get_clock_info() */
+typedef struct {
+    const char *implementation;
+    int monotonic;
+    int adjustable;
+    double resolution;
+} _Py_clock_info_t;
+
+/* Get the current time from the system clock.
+ * Fill clock information if info is not NULL.
+ * Raise an exception and return -1 on error, return 0 on success.
+ */
+PyAPI_FUNC(int) _PyTime_GetSystemClockWithInfo(
+    _PyTime_t *t,
+    _Py_clock_info_t *info);
+
+/* Get the time of a monotonic clock, i.e. a clock that cannot go backwards.
+   The clock is not affected by system clock updates. The reference point of
+   the returned value is undefined, so that only the difference between the
+   results of consecutive calls is valid.
+
+   Fill info (if set) with information of the function used to get the time.
+
+   Return 0 on success, raise an exception and return -1 on error. */
+PyAPI_FUNC(int) _PyTime_GetMonotonicClockWithInfo(
+    _PyTime_t *t,
+    _Py_clock_info_t *info);
+
+
+/* Initialize time.
+   Return 0 on success, raise an exception and return -1 on error. */
+PyAPI_FUNC(int) _PyTime_Init(void);
+
+/* Converts a timestamp to the Gregorian time, using the local time zone.
+   Return 0 on success, raise an exception and return -1 on error. */
+PyAPI_FUNC(int) _PyTime_localtime(time_t t, struct tm *tm);
+
+/* Converts a timestamp to the Gregorian time, assuming UTC.
+   Return 0 on success, raise an exception and return -1 on error. */
+PyAPI_FUNC(int) _PyTime_gmtime(time_t t, struct tm *tm);
+
+/* Get the performance counter: clock with the highest available resolution to
+   measure a short duration.
+
+   The function cannot fail. _PyTime_Init() ensures that the system clock
+   works. */
+PyAPI_FUNC(_PyTime_t) _PyTime_GetPerfCounter(void);
+
+/* Get the performance counter: clock with the highest available resolution to
+   measure a short duration.
+
+   Fill info (if set) with information of the function used to get the time.
+
+   Return 0 on success, raise an exception and return -1 on error. */
+PyAPI_FUNC(int) _PyTime_GetPerfCounterWithInfo(
+    _PyTime_t *t,
+    _Py_clock_info_t *info);
+
+/* Cast double x to time_t, but raise ValueError if x is too large
+ * to fit in a time_t.  ValueError is set on return iff the return
+ * value is (time_t)-1 and PyErr_Occurred().
+ */
+PyAPI_FUNC(time_t) _PyTime_DoubleToTimet(double x);
+
+/* Get the current time since the epoch in seconds */
+PyAPI_FUNC(double) _PyTime_FloatTime(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* Py_PYTIME_H */
+#endif /* Py_LIMITED_API */

--- a/Include/pytime.h
+++ b/Include/pytime.h
@@ -5,11 +5,6 @@
 #include "pyconfig.h" /* include for defines */
 #include "object.h"
 
-/* Include C99 integer types as per posix */
-#ifdef HAVE_STDINT_H
-#include <stdint.h>
-#endif
-
 /**************************************************************************
 Symbols and macros to supply platform-independent interfaces to time related
 functions and constants

--- a/Include/pytime.h
+++ b/Include/pytime.h
@@ -5,6 +5,11 @@
 #include "pyconfig.h" /* include for defines */
 #include "object.h"
 
+/* Include C99 integer types as per posix */
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
+
 /**************************************************************************
 Symbols and macros to supply platform-independent interfaces to time related
 functions and constants

--- a/Include/pytime.h
+++ b/Include/pytime.h
@@ -3,6 +3,7 @@
 #define Py_PYTIME_H
 
 #include "pyconfig.h" /* include for defines */
+#include "pyport.h"
 #include "object.h"
 
 /**************************************************************************
@@ -16,7 +17,7 @@ extern "C" {
 /* _PyTime_t: Python timestamp with subsecond precision. It can be used to
    store a duration, and so indirectly a date (related to another date, like
    UNIX epoch). */
-typedef int64_t _PyTime_t;
+typedef PY_INT64_T _PyTime_t;
 #define _PyTime_MIN PY_LLONG_MIN
 #define _PyTime_MAX PY_LLONG_MAX
 

--- a/Include/timefuncs.h
+++ b/Include/timefuncs.h
@@ -1,26 +1,11 @@
-/*  timefuncs.h
- */
-
-/* Utility function related to timemodule.c. */
-
+/*  timefuncs.h */
+/*
+    This is included only for backwards compatibility with C modules that
+    depend on this header file.
+*/
 #ifndef TIMEFUNCS_H
 #define TIMEFUNCS_H
-#ifdef __cplusplus
-extern "C" {
+
+#include "pytime.h"
+
 #endif
-
-
-/* Cast double x to time_t, but raise ValueError if x is too large
- * to fit in a time_t.  ValueError is set on return iff the return
- * value is (time_t)-1 and PyErr_Occurred().
- */
-PyAPI_FUNC(time_t) _PyTime_DoubleToTimet(double x);
-
-/* Get the current time since the epoch in seconds */
-PyAPI_FUNC(double) _PyTime_FloatTime(void);
-
-
-#ifdef __cplusplus
-}
-#endif
-#endif  /* TIMEFUNCS_H */

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -385,7 +385,7 @@ class TimeTestCase(unittest.TestCase):
         for t in (-2, -1, 0, 1):
             try:
                 tt = time.localtime(t)
-            except (OverflowError, ValueError):
+            except ValueError:
                 pass
             else:
                 self.assertEqual(time.mktime(tt), t)
@@ -403,7 +403,7 @@ class TimeTestCase(unittest.TestCase):
         self.assertNotEqual(tzname, 'LMT')
         try:
             time.mktime((-1, 1, 1, 0, 0, 0, -1, -1, -1))
-        except OverflowError:
+        except ValueError:
             pass
         self.assertEqual(time.strftime('%Z', tt), tzname)
 

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -3,12 +3,19 @@ import time
 import unittest
 import sys
 import sysconfig
+import platform
+import threading
 
 
 # Max year is only limited by the size of C int.
 SIZEOF_INT = sysconfig.get_config_var('SIZEOF_INT') or 4
 TIME_MAXYEAR = (1 << 8 * SIZEOF_INT - 1) - 1
 
+def busy_wait(duration):
+    deadline = time.monotonic() + duration
+    while time.monotonic() < deadline:
+        pass
+    return
 
 class TimeTestCase(unittest.TestCase):
 
@@ -24,6 +31,77 @@ class TimeTestCase(unittest.TestCase):
     def test_clock(self):
         time.clock()
 
+    def test_time_ns_type(self):
+        def check_ns(sec, ns):
+            self.assertIsInstance(ns, long)
+
+            sec_ns = int(sec * 1e9)
+            # tolerate a difference of 50 ms
+            self.assertLess((sec_ns - ns), 50 ** 6, (sec, ns))
+
+        check_ns(time.time(),
+                 time.time_ns())
+        check_ns(time.monotonic(),
+                 time.monotonic_ns())
+        check_ns(time.perf_counter(),
+                 time.perf_counter_ns())
+        check_ns(time.process_time(),
+                 time.process_time_ns())
+
+        if hasattr(time, 'thread_time'):
+            check_ns(time.thread_time(),
+                     time.thread_time_ns())
+
+        if hasattr(time, 'clock_gettime'):
+            check_ns(time.clock_gettime(time.CLOCK_REALTIME),
+                     time.clock_gettime_ns(time.CLOCK_REALTIME))
+
+    @unittest.skipUnless(hasattr(time, 'clock_gettime'),
+                         'need time.clock_gettime()')
+    def test_clock_realtime(self):
+        t = time.clock_gettime(time.CLOCK_REALTIME)
+        self.assertIsInstance(t, float)
+
+    @unittest.skipUnless(hasattr(time, 'clock_gettime'),
+                         'need time.clock_gettime()')
+    @unittest.skipUnless(hasattr(time, 'CLOCK_MONOTONIC'),
+                         'need time.CLOCK_MONOTONIC')
+    def test_clock_monotonic(self):
+        a = time.clock_gettime(time.CLOCK_MONOTONIC)
+        b = time.clock_gettime(time.CLOCK_MONOTONIC)
+        self.assertLessEqual(a, b)
+
+    @unittest.skipUnless(hasattr(time, 'pthread_getcpuclockid'),
+                         'need time.pthread_getcpuclockid()')
+    @unittest.skipUnless(hasattr(time, 'clock_gettime'),
+                         'need time.clock_gettime()')
+    def test_pthread_getcpuclockid(self):
+        clk_id = time.pthread_getcpuclockid(threading.get_ident())
+        self.assertTrue(type(clk_id) is int)
+        self.assertNotEqual(clk_id, time.CLOCK_THREAD_CPUTIME_ID)
+        t1 = time.clock_gettime(clk_id)
+        t2 = time.clock_gettime(clk_id)
+        self.assertLessEqual(t1, t2)
+
+    @unittest.skipUnless(hasattr(time, 'clock_getres'),
+                         'need time.clock_getres()')
+    def test_clock_getres(self):
+        res = time.clock_getres(time.CLOCK_REALTIME)
+        self.assertGreater(res, 0.0)
+        self.assertLessEqual(res, 1.0)
+
+    @unittest.skipUnless(hasattr(time, 'clock_settime'),
+                         'need time.clock_settime()')
+    def test_clock_settime(self):
+        t = time.clock_gettime(time.CLOCK_REALTIME)
+        try:
+            time.clock_settime(time.CLOCK_REALTIME, t)
+        except PermissionError:
+            pass
+
+        if hasattr(time, 'CLOCK_MONOTONIC'):
+            self.assertRaises(OSError,
+                              time.clock_settime, time.CLOCK_MONOTONIC, 0)
     def test_conversions(self):
         self.assertTrue(time.ctime(self.t)
                      == time.asctime(time.localtime(self.t)))
@@ -312,6 +390,140 @@ class TimeTestCase(unittest.TestCase):
             else:
                 self.assertEqual(time.mktime(tt), t)
 
+    # Issue #13309: passing extreme values to mktime() or localtime()
+    # borks the glibc's internal timezone data.
+    @unittest.skipUnless(platform.libc_ver()[0] != 'glibc',
+                         "disabled because of a bug in glibc. Issue #13309")
+    def test_mktime_error(self):
+        # It may not be possible to reliably make mktime return error
+        # on all platfom.  This will make sure that no other exception
+        # than OverflowError is raised for an extreme value.
+        tt = time.gmtime(self.t)
+        tzname = time.strftime('%Z', tt)
+        self.assertNotEqual(tzname, 'LMT')
+        try:
+            time.mktime((-1, 1, 1, 0, 0, 0, -1, -1, -1))
+        except OverflowError:
+            pass
+        self.assertEqual(time.strftime('%Z', tt), tzname)
+
+    def test_monotonic(self):
+        # monotonic() should not go backward
+        times = [time.monotonic() for n in range(100)]
+        t1 = times[0]
+        for t2 in times[1:]:
+            self.assertGreaterEqual(t2, t1, "times=%s" % times)
+            t1 = t2
+
+        # monotonic() includes time elapsed during a sleep
+        t1 = time.monotonic()
+        time.sleep(0.5)
+        t2 = time.monotonic()
+        dt = t2 - t1
+        self.assertGreater(t2, t1)
+        # Issue #20101: On some Windows machines, dt may be slightly low
+        self.assertTrue(0.45 <= dt <= 1.0, dt)
+
+    def test_perf_counter(self):
+        time.perf_counter()
+
+    def test_process_time(self):
+        # process_time() should not include time spend during a sleep
+        start = time.process_time()
+        time.sleep(0.100)
+        stop = time.process_time()
+        # use 20 ms because process_time() has usually a resolution of 15 ms
+        # on Windows
+        self.assertLess(stop - start, 0.020)
+
+        # bpo-33723: A busy loop of 100 ms should increase process_time()
+        # by at least 15 ms
+        min_time = 0.015
+        busy_time = 0.100
+
+        # process_time() should include CPU time spent in any thread
+        start = time.process_time()
+        busy_wait(busy_time)
+        stop = time.process_time()
+        self.assertGreaterEqual(stop - start, min_time)
+
+        t = threading.Thread(target=busy_wait, args=(busy_time,))
+        start = time.process_time()
+        t.start()
+        t.join()
+        stop = time.process_time()
+        self.assertGreaterEqual(stop - start, min_time)
+
+    def test_thread_time(self):
+        if not hasattr(time, 'thread_time'):
+            if sys.platform.startswith(('linux', 'win')):
+                self.fail("time.thread_time() should be available on %r"
+                          % (sys.platform,))
+            else:
+                self.skipTest("need time.thread_time")
+
+        # thread_time() should not include time spend during a sleep
+        start = time.thread_time()
+        time.sleep(0.100)
+        stop = time.thread_time()
+        # use 20 ms because thread_time() has usually a resolution of 15 ms
+        # on Windows
+        self.assertLess(stop - start, 0.020)
+
+        # bpo-33723: A busy loop of 100 ms should increase thread_time()
+        # by at least 15 ms
+        min_time = 0.015
+        busy_time = 0.100
+
+        # thread_time() should include CPU time spent in current thread...
+        start = time.thread_time()
+        busy_wait(busy_time)
+        stop = time.thread_time()
+        self.assertGreaterEqual(stop - start, min_time)
+
+        # ...but not in other threads
+        t = threading.Thread(target=busy_wait, args=(busy_time,))
+        start = time.thread_time()
+        t.start()
+        t.join()
+        stop = time.thread_time()
+        self.assertLess(stop - start, min_time)
+
+    @unittest.skipUnless(hasattr(time, 'clock_settime'),
+                         'need time.clock_settime')
+    def test_monotonic_settime(self):
+        t1 = time.monotonic()
+        realtime = time.clock_gettime(time.CLOCK_REALTIME)
+        # jump backward with an offset of 1 hour
+        try:
+            time.clock_settime(time.CLOCK_REALTIME, realtime - 3600)
+        except PermissionError as err:
+            self.skipTest(err)
+        t2 = time.monotonic()
+        time.clock_settime(time.CLOCK_REALTIME, realtime)
+        # monotonic must not be affected by system clock updates
+        self.assertGreaterEqual(t2, t1)
+
+    def test_localtime_failure(self):
+        # Issue #13847: check for localtime() failure
+        invalid_time_t = None
+        for time_t in (-1, 2**30, 2**33, 2**60):
+            try:
+                time.localtime(time_t)
+            except (ValueError, OverflowError):
+                self.skipTest("need 64-bit time_t")
+            except OSError:
+                invalid_time_t = time_t
+                break
+        if invalid_time_t is None:
+            self.skipTest("unable to find an invalid time_t value")
+
+        self.assertRaises(OSError, time.localtime, invalid_time_t)
+        self.assertRaises(OSError, time.ctime, invalid_time_t)
+
+        # Issue #26669: check for localtime() failure
+        self.assertRaises(ValueError, time.localtime, float("nan"))
+        self.assertRaises(ValueError, time.ctime, float("nan"))
 
 def test_main():
     test_support.run_unittest(TimeTestCase)

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -813,6 +813,7 @@ PYTHON_HEADERS= \
 		Include/pyfpe.h \
 		Include/pymath.h \
 		Include/pygetopt.h \
+		Include/pymacro.h \
 		Include/pymem.h \
 		Include/pyport.h \
 		Include/pystate.h \

--- a/Modules/datetimemodule.c
+++ b/Modules/datetimemodule.c
@@ -10,7 +10,7 @@
 
 #include <time.h>
 
-#include "timefuncs.h"
+#include "pytime.h"
 
 /* Differentiate between building the core module and building extension
  * modules.

--- a/Modules/pytime.c
+++ b/Modules/pytime.c
@@ -770,6 +770,11 @@ pymonotonic(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
 
     assert(info == NULL || raise);
 
+    // FIXME: GetTickCount64 is only available on Windows Vista and greater. In
+    //        order to enable backwards-compatibility, we need another monotonic
+    //        source that returns a 64-bit Integer. Maybe QueryPerformanceCounter
+    //        can be utilised as a workaround?
+
     ticks = GetTickCount64();
     Py_BUILD_ASSERT(sizeof(ticks) <= sizeof(_PyTime_t));
     t = (_PyTime_t)ticks;

--- a/Modules/pytime.c
+++ b/Modules/pytime.c
@@ -1,0 +1,1106 @@
+#include "Python.h"
+#ifdef MS_WINDOWS
+#include <windows.h>
+#endif
+
+#if defined(__APPLE__)
+#include <mach/mach_time.h>   /* mach_absolute_time(), mach_timebase_info() */
+#endif
+
+#define _PyTime_check_mul_overflow(a, b) \
+    (assert(b > 0), \
+     (_PyTime_t)(a) < _PyTime_MIN / (_PyTime_t)(b) \
+     || _PyTime_MAX / (_PyTime_t)(b) < (_PyTime_t)(a))
+
+/* To millisecond (10^-3) */
+#define SEC_TO_MS 1000
+
+/* To microseconds (10^-6) */
+#define MS_TO_US 1000
+#define SEC_TO_US (SEC_TO_MS * MS_TO_US)
+
+/* To nanoseconds (10^-9) */
+#define US_TO_NS 1000
+#define MS_TO_NS (MS_TO_US * US_TO_NS)
+#define SEC_TO_NS (SEC_TO_MS * MS_TO_NS)
+
+/* Conversion from nanoseconds */
+#define NS_TO_MS (1000 * 1000)
+#define NS_TO_US (1000)
+
+static void
+error_time_t_overflow(void)
+{
+    PyErr_SetString(PyExc_OverflowError,
+                    "timestamp out of range for platform time_t");
+}
+
+static void
+_PyTime_overflow(void)
+{
+    PyErr_SetString(PyExc_OverflowError,
+                    "timestamp too large to convert to C _PyTime_t");
+}
+
+
+_PyTime_t
+_PyTime_MulDiv(_PyTime_t ticks, _PyTime_t mul, _PyTime_t div)
+{
+    _PyTime_t intpart, remaining;
+    /* Compute (ticks * mul / div) in two parts to prevent integer overflow:
+       compute integer part, and then the remaining part.
+
+       (ticks * mul) / div == (ticks / div) * mul + (ticks % div) * mul / div
+
+       The caller must ensure that "(div - 1) * mul" cannot overflow. */
+    intpart = ticks / div;
+    ticks %= div;
+    remaining = ticks * mul;
+    remaining /= div;
+    return intpart * mul + remaining;
+}
+
+
+time_t
+_PyLong_AsTime_t(PyObject *obj)
+{
+#if SIZEOF_TIME_T == SIZEOF_LONG_LONG
+    long long val;
+    val = PyLong_AsLongLong(obj);
+#else
+    long val;
+    Py_BUILD_ASSERT(sizeof(time_t) <= sizeof(long));
+    val = PyLong_AsLong(obj);
+#endif
+    if (val == -1 && PyErr_Occurred()) {
+        if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+            error_time_t_overflow();
+        }
+        return -1;
+    }
+    return (time_t)val;
+}
+
+PyObject *
+_PyLong_FromTime_t(time_t t)
+{
+#if SIZEOF_TIME_T == SIZEOF_LONG_LONG
+    return PyLong_FromLongLong((long long)t);
+#else
+    Py_BUILD_ASSERT(sizeof(time_t) <= sizeof(long));
+    return PyLong_FromLong((long)t);
+#endif
+}
+
+/* Round to nearest with ties going to nearest even integer
+   (_PyTime_ROUND_HALF_EVEN) */
+static double
+_PyTime_RoundHalfEven(double x)
+{
+    double rounded = round(x);
+    if (fabs(x-rounded) == 0.5) {
+        /* halfway case: round to even */
+        rounded = 2.0*round(x/2.0);
+    }
+    return rounded;
+}
+
+static double
+_PyTime_Round(double x, _PyTime_round_t round)
+{
+    /* volatile avoids optimization changing how numbers are rounded */
+    volatile double d;
+
+    d = x;
+    if (round == _PyTime_ROUND_HALF_EVEN) {
+        d = _PyTime_RoundHalfEven(d);
+    }
+    else if (round == _PyTime_ROUND_CEILING) {
+        d = ceil(d);
+    }
+    else if (round == _PyTime_ROUND_FLOOR) {
+        d = floor(d);
+    }
+    else {
+        assert(round == _PyTime_ROUND_UP);
+        d = (d >= 0.0) ? ceil(d) : floor(d);
+    }
+    return d;
+}
+
+static int
+_PyTime_DoubleToDenominator(double d, time_t *sec, long *numerator,
+                            long idenominator, _PyTime_round_t round)
+{
+    double denominator = (double)idenominator;
+    double intpart;
+    /* volatile avoids optimization changing how numbers are rounded */
+    volatile double floatpart;
+
+    floatpart = modf(d, &intpart);
+
+    floatpart *= denominator;
+    floatpart = _PyTime_Round(floatpart, round);
+    if (floatpart >= denominator) {
+        floatpart -= denominator;
+        intpart += 1.0;
+    }
+    else if (floatpart < 0) {
+        floatpart += denominator;
+        intpart -= 1.0;
+    }
+    assert(0.0 <= floatpart && floatpart < denominator);
+
+    if (!_Py_InIntegralTypeRange(time_t, intpart)) {
+        error_time_t_overflow();
+        return -1;
+    }
+    *sec = (time_t)intpart;
+    *numerator = (long)floatpart;
+    assert(0 <= *numerator && *numerator < idenominator);
+    return 0;
+}
+
+static int
+_PyTime_ObjectToDenominator(PyObject *obj, time_t *sec, long *numerator,
+                            long denominator, _PyTime_round_t round)
+{
+    assert(denominator >= 1);
+
+    if (PyFloat_Check(obj)) {
+        double d = PyFloat_AsDouble(obj);
+        if (Py_IS_NAN(d)) {
+            *numerator = 0;
+            PyErr_SetString(PyExc_ValueError, "Invalid value NaN (not a number)");
+            return -1;
+        }
+        return _PyTime_DoubleToDenominator(d, sec, numerator,
+                                           denominator, round);
+    }
+    else {
+        *sec = _PyLong_AsTime_t(obj);
+        *numerator = 0;
+        if (*sec == (time_t)-1 && PyErr_Occurred()) {
+            return -1;
+        }
+        return 0;
+    }
+}
+
+int
+_PyTime_ObjectToTime_t(PyObject *obj, time_t *sec, _PyTime_round_t round)
+{
+    if (PyFloat_Check(obj)) {
+        double intpart;
+        /* volatile avoids optimization changing how numbers are rounded */
+        volatile double d;
+
+        d = PyFloat_AsDouble(obj);
+        if (Py_IS_NAN(d)) {
+            PyErr_SetString(PyExc_ValueError, "Invalid value NaN (not a number)");
+            return -1;
+        }
+
+        d = _PyTime_Round(d, round);
+        (void)modf(d, &intpart);
+
+        if (!_Py_InIntegralTypeRange(time_t, intpart)) {
+            error_time_t_overflow();
+            return -1;
+        }
+        *sec = (time_t)intpart;
+        return 0;
+    }
+    else {
+        *sec = _PyLong_AsTime_t(obj);
+        if (*sec == (time_t)-1 && PyErr_Occurred()) {
+            return -1;
+        }
+        return 0;
+    }
+}
+
+int
+_PyTime_ObjectToTimespec(PyObject *obj, time_t *sec, long *nsec,
+                         _PyTime_round_t round)
+{
+    return _PyTime_ObjectToDenominator(obj, sec, nsec, SEC_TO_NS, round);
+}
+
+int
+_PyTime_ObjectToTimeval(PyObject *obj, time_t *sec, long *usec,
+                        _PyTime_round_t round)
+{
+    return _PyTime_ObjectToDenominator(obj, sec, usec, SEC_TO_US, round);
+}
+
+_PyTime_t
+_PyTime_FromSeconds(int seconds)
+{
+    _PyTime_t t;
+    /* ensure that integer overflow cannot happen, int type should have 32
+       bits, whereas _PyTime_t type has at least 64 bits (SEC_TO_MS takes 30
+       bits). */
+    Py_BUILD_ASSERT(INT_MAX <= _PyTime_MAX / SEC_TO_NS);
+    Py_BUILD_ASSERT(INT_MIN >= _PyTime_MIN / SEC_TO_NS);
+
+    t = (_PyTime_t)seconds;
+    assert((t >= 0 && t <= _PyTime_MAX / SEC_TO_NS)
+           || (t < 0 && t >= _PyTime_MIN / SEC_TO_NS));
+    t *= SEC_TO_NS;
+    return t;
+}
+
+_PyTime_t
+_PyTime_FromNanoseconds(_PyTime_t ns)
+{
+    /* _PyTime_t already uses nanosecond resolution, no conversion needed */
+    return ns;
+}
+
+int
+_PyTime_FromNanosecondsObject(_PyTime_t *tp, PyObject *obj)
+{
+    long long nsec;
+    _PyTime_t t;
+
+    if (!PyLong_Check(obj)) {
+        PyErr_Format(PyExc_TypeError, "expect int, got %s",
+                     Py_TYPE(obj)->tp_name);
+        return -1;
+    }
+
+    Py_BUILD_ASSERT(sizeof(long long) == sizeof(_PyTime_t));
+    nsec = PyLong_AsLongLong(obj);
+    if (nsec == -1 && PyErr_Occurred()) {
+        if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+            _PyTime_overflow();
+        }
+        return -1;
+    }
+
+    /* _PyTime_t already uses nanosecond resolution, no conversion needed */
+    t = (_PyTime_t)nsec;
+    *tp = t;
+    return 0;
+}
+
+#ifdef HAVE_CLOCK_GETTIME
+static int
+pytime_fromtimespec(_PyTime_t *tp, struct timespec *ts, int raise)
+{
+    _PyTime_t t, nsec;
+    int res = 0;
+
+    Py_BUILD_ASSERT(sizeof(ts->tv_sec) <= sizeof(_PyTime_t));
+    t = (_PyTime_t)ts->tv_sec;
+
+    if (_PyTime_check_mul_overflow(t, SEC_TO_NS)) {
+        if (raise) {
+            _PyTime_overflow();
+        }
+        res = -1;
+        t = (t > 0) ? _PyTime_MAX : _PyTime_MIN;
+    }
+    else {
+        t = t * SEC_TO_NS;
+    }
+
+    nsec = ts->tv_nsec;
+    /* The following test is written for positive only nsec */
+    assert(nsec >= 0);
+    if (t > _PyTime_MAX - nsec) {
+        if (raise) {
+            _PyTime_overflow();
+        }
+        res = -1;
+        t = _PyTime_MAX;
+    }
+    else {
+        t += nsec;
+    }
+
+    *tp = t;
+    return res;
+}
+
+int
+_PyTime_FromTimespec(_PyTime_t *tp, struct timespec *ts)
+{
+    return pytime_fromtimespec(tp, ts, 1);
+}
+#endif
+
+#if !defined(MS_WINDOWS)
+static int
+pytime_fromtimeval(_PyTime_t *tp, struct timeval *tv, int raise)
+{
+    _PyTime_t t, usec;
+    int res = 0;
+
+    Py_BUILD_ASSERT(sizeof(tv->tv_sec) <= sizeof(_PyTime_t));
+    t = (_PyTime_t)tv->tv_sec;
+
+    if (_PyTime_check_mul_overflow(t, SEC_TO_NS)) {
+        if (raise) {
+            _PyTime_overflow();
+        }
+        res = -1;
+        t = (t > 0) ? _PyTime_MAX : _PyTime_MIN;
+    }
+    else {
+        t = t * SEC_TO_NS;
+    }
+
+    usec = (_PyTime_t)tv->tv_usec * US_TO_NS;
+    /* The following test is written for positive only usec */
+    assert(usec >= 0);
+    if (t > _PyTime_MAX - usec) {
+        if (raise) {
+            _PyTime_overflow();
+        }
+        res = -1;
+        t = _PyTime_MAX;
+    }
+    else {
+        t += usec;
+    }
+
+    *tp = t;
+    return res;
+}
+
+int
+_PyTime_FromTimeval(_PyTime_t *tp, struct timeval *tv)
+{
+    return pytime_fromtimeval(tp, tv, 1);
+}
+#endif
+
+static int
+_PyTime_FromDouble(_PyTime_t *t, double value, _PyTime_round_t round,
+                   long unit_to_ns)
+{
+    /* volatile avoids optimization changing how numbers are rounded */
+    volatile double d;
+
+    /* convert to a number of nanoseconds */
+    d = value;
+    d *= (double)unit_to_ns;
+    d = _PyTime_Round(d, round);
+
+    if (!_Py_InIntegralTypeRange(_PyTime_t, d)) {
+        _PyTime_overflow();
+        return -1;
+    }
+    *t = (_PyTime_t)d;
+    return 0;
+}
+
+static int
+_PyTime_FromObject(_PyTime_t *t, PyObject *obj, _PyTime_round_t round,
+                   long unit_to_ns)
+{
+    if (PyFloat_Check(obj)) {
+        double d;
+        d = PyFloat_AsDouble(obj);
+        if (Py_IS_NAN(d)) {
+            PyErr_SetString(PyExc_ValueError, "Invalid value NaN (not a number)");
+            return -1;
+        }
+        return _PyTime_FromDouble(t, d, round, unit_to_ns);
+    }
+    else {
+        long long sec;
+        Py_BUILD_ASSERT(sizeof(long long) <= sizeof(_PyTime_t));
+
+        sec = PyLong_AsLongLong(obj);
+        if (sec == -1 && PyErr_Occurred()) {
+            if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+                _PyTime_overflow();
+            }
+            return -1;
+        }
+
+        if (_PyTime_check_mul_overflow(sec, unit_to_ns)) {
+            _PyTime_overflow();
+            return -1;
+        }
+        *t = sec * unit_to_ns;
+        return 0;
+    }
+}
+
+int
+_PyTime_FromSecondsObject(_PyTime_t *t, PyObject *obj, _PyTime_round_t round)
+{
+    return _PyTime_FromObject(t, obj, round, SEC_TO_NS);
+}
+
+int
+_PyTime_FromMillisecondsObject(_PyTime_t *t, PyObject *obj, _PyTime_round_t round)
+{
+    return _PyTime_FromObject(t, obj, round, MS_TO_NS);
+}
+
+double
+_PyTime_AsSecondsDouble(_PyTime_t t)
+{
+    /* volatile avoids optimization changing how numbers are rounded */
+    volatile double d;
+
+    if (t % SEC_TO_NS == 0) {
+        _PyTime_t secs;
+        /* Divide using integers to avoid rounding issues on the integer part.
+           1e-9 cannot be stored exactly in IEEE 64-bit. */
+        secs = t / SEC_TO_NS;
+        d = (double)secs;
+    }
+    else {
+        d = (double)t;
+        d /= 1e9;
+    }
+    return d;
+}
+
+PyObject *
+_PyTime_AsNanosecondsObject(_PyTime_t t)
+{
+    Py_BUILD_ASSERT(sizeof(long long) >= sizeof(_PyTime_t));
+    return PyLong_FromLongLong((long long)t);
+}
+
+static _PyTime_t
+_PyTime_Divide(const _PyTime_t t, const _PyTime_t k,
+               const _PyTime_round_t round)
+{
+    assert(k > 1);
+    if (round == _PyTime_ROUND_HALF_EVEN) {
+        _PyTime_t x, r, abs_r;
+        x = t / k;
+        r = t % k;
+        abs_r = Py_ABS(r);
+        if (abs_r > k / 2 || (abs_r == k / 2 && (Py_ABS(x) & 1))) {
+            if (t >= 0) {
+                x++;
+            }
+            else {
+                x--;
+            }
+        }
+        return x;
+    }
+    else if (round == _PyTime_ROUND_CEILING) {
+        if (t >= 0) {
+            return (t + k - 1) / k;
+        }
+        else {
+            return t / k;
+        }
+    }
+    else if (round == _PyTime_ROUND_FLOOR){
+        if (t >= 0) {
+            return t / k;
+        }
+        else {
+            return (t - (k - 1)) / k;
+        }
+    }
+    else {
+        assert(round == _PyTime_ROUND_UP);
+        if (t >= 0) {
+            return (t + k - 1) / k;
+        }
+        else {
+            return (t - (k - 1)) / k;
+        }
+    }
+}
+
+_PyTime_t
+_PyTime_AsMilliseconds(_PyTime_t t, _PyTime_round_t round)
+{
+    return _PyTime_Divide(t, NS_TO_MS, round);
+}
+
+_PyTime_t
+_PyTime_AsMicroseconds(_PyTime_t t, _PyTime_round_t round)
+{
+    return _PyTime_Divide(t, NS_TO_US, round);
+}
+
+static int
+_PyTime_AsTimeval_impl(_PyTime_t t, _PyTime_t *p_secs, int *p_us,
+                       _PyTime_round_t round)
+{
+    _PyTime_t secs, ns;
+    int usec;
+    int res = 0;
+
+    secs = t / SEC_TO_NS;
+    ns = t % SEC_TO_NS;
+
+    usec = (int)_PyTime_Divide(ns, US_TO_NS, round);
+    if (usec < 0) {
+        usec += SEC_TO_US;
+        if (secs != _PyTime_MIN) {
+            secs -= 1;
+        }
+        else {
+            res = -1;
+        }
+    }
+    else if (usec >= SEC_TO_US) {
+        usec -= SEC_TO_US;
+        if (secs != _PyTime_MAX) {
+            secs += 1;
+        }
+        else {
+            res = -1;
+        }
+    }
+    assert(0 <= usec && usec < SEC_TO_US);
+
+    *p_secs = secs;
+    *p_us = usec;
+
+    return res;
+}
+
+static int
+_PyTime_AsTimevalStruct_impl(_PyTime_t t, struct timeval *tv,
+                             _PyTime_round_t round, int raise)
+{
+    _PyTime_t secs, secs2;
+    int us;
+    int res;
+
+    res = _PyTime_AsTimeval_impl(t, &secs, &us, round);
+
+#ifdef MS_WINDOWS
+    tv->tv_sec = (long)secs;
+#else
+    tv->tv_sec = secs;
+#endif
+    tv->tv_usec = us;
+
+    secs2 = (_PyTime_t)tv->tv_sec;
+    if (res < 0 || secs2 != secs) {
+        if (raise) {
+            error_time_t_overflow();
+        }
+        return -1;
+    }
+    return 0;
+}
+
+int
+_PyTime_AsTimeval(_PyTime_t t, struct timeval *tv, _PyTime_round_t round)
+{
+    return _PyTime_AsTimevalStruct_impl(t, tv, round, 1);
+}
+
+int
+_PyTime_AsTimeval_noraise(_PyTime_t t, struct timeval *tv, _PyTime_round_t round)
+{
+    return _PyTime_AsTimevalStruct_impl(t, tv, round, 0);
+}
+
+int
+_PyTime_AsTimevalTime_t(_PyTime_t t, time_t *p_secs, int *us,
+                        _PyTime_round_t round)
+{
+    _PyTime_t secs;
+    int res;
+
+    res = _PyTime_AsTimeval_impl(t, &secs, us, round);
+
+    *p_secs = secs;
+
+    if (res < 0 || (_PyTime_t)*p_secs != secs) {
+        error_time_t_overflow();
+        return -1;
+    }
+    return 0;
+}
+
+
+#if defined(HAVE_CLOCK_GETTIME) || defined(HAVE_KQUEUE)
+int
+_PyTime_AsTimespec(_PyTime_t t, struct timespec *ts)
+{
+    _PyTime_t secs, nsec;
+
+    secs = t / SEC_TO_NS;
+    nsec = t % SEC_TO_NS;
+    if (nsec < 0) {
+        nsec += SEC_TO_NS;
+        secs -= 1;
+    }
+    ts->tv_sec = (time_t)secs;
+    assert(0 <= nsec && nsec < SEC_TO_NS);
+    ts->tv_nsec = nsec;
+
+    if ((_PyTime_t)ts->tv_sec != secs) {
+        error_time_t_overflow();
+        return -1;
+    }
+    return 0;
+}
+#endif
+
+static int
+pygettimeofday(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
+{
+#ifdef MS_WINDOWS
+    FILETIME system_time;
+    ULARGE_INTEGER large;
+
+    assert(info == NULL || raise);
+
+    GetSystemTimeAsFileTime(&system_time);
+    large.u.LowPart = system_time.dwLowDateTime;
+    large.u.HighPart = system_time.dwHighDateTime;
+    /* 11,644,473,600,000,000,000: number of nanoseconds between
+       the 1st january 1601 and the 1st january 1970 (369 years + 89 leap
+       days). */
+    *tp = large.QuadPart * 100 - 11644473600000000000;
+    if (info) {
+        DWORD timeAdjustment, timeIncrement;
+        BOOL isTimeAdjustmentDisabled, ok;
+
+        info->implementation = "GetSystemTimeAsFileTime()";
+        info->monotonic = 0;
+        ok = GetSystemTimeAdjustment(&timeAdjustment, &timeIncrement,
+                                     &isTimeAdjustmentDisabled);
+        if (!ok) {
+            PyErr_SetFromWindowsErr(0);
+            return -1;
+        }
+        info->resolution = timeIncrement * 1e-7;
+        info->adjustable = 1;
+    }
+
+#else   /* MS_WINDOWS */
+    int err;
+#ifdef HAVE_CLOCK_GETTIME
+    struct timespec ts;
+#else
+    struct timeval tv;
+#endif
+
+    assert(info == NULL || raise);
+
+#ifdef HAVE_CLOCK_GETTIME
+    err = clock_gettime(CLOCK_REALTIME, &ts);
+    if (err) {
+        if (raise) {
+            PyErr_SetFromErrno(PyExc_OSError);
+        }
+        return -1;
+    }
+    if (pytime_fromtimespec(tp, &ts, raise) < 0) {
+        return -1;
+    }
+
+    if (info) {
+        struct timespec res;
+        info->implementation = "clock_gettime(CLOCK_REALTIME)";
+        info->monotonic = 0;
+        info->adjustable = 1;
+        if (clock_getres(CLOCK_REALTIME, &res) == 0) {
+            info->resolution = res.tv_sec + res.tv_nsec * 1e-9;
+        }
+        else {
+            info->resolution = 1e-9;
+        }
+    }
+#else   /* HAVE_CLOCK_GETTIME */
+
+     /* test gettimeofday() */
+#ifdef GETTIMEOFDAY_NO_TZ
+    err = gettimeofday(&tv);
+#else
+    err = gettimeofday(&tv, (struct timezone *)NULL);
+#endif
+    if (err) {
+        if (raise) {
+            PyErr_SetFromErrno(PyExc_OSError);
+        }
+        return -1;
+    }
+    if (pytime_fromtimeval(tp, &tv, raise) < 0) {
+        return -1;
+    }
+
+    if (info) {
+        info->implementation = "gettimeofday()";
+        info->resolution = 1e-6;
+        info->monotonic = 0;
+        info->adjustable = 1;
+    }
+#endif   /* !HAVE_CLOCK_GETTIME */
+#endif   /* !MS_WINDOWS */
+    return 0;
+}
+
+_PyTime_t
+_PyTime_GetSystemClock(void)
+{
+    _PyTime_t t;
+    if (pygettimeofday(&t, NULL, 0) < 0) {
+        /* should not happen, _PyTime_Init() checked the clock at startup */
+        Py_UNREACHABLE();
+    }
+    return t;
+}
+
+int
+_PyTime_GetSystemClockWithInfo(_PyTime_t *t, _Py_clock_info_t *info)
+{
+    return pygettimeofday(t, info, 1);
+}
+
+static int
+pymonotonic(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
+{
+#if defined(MS_WINDOWS)
+    ULONGLONG ticks;
+    _PyTime_t t;
+
+    assert(info == NULL || raise);
+
+    ticks = GetTickCount64();
+    Py_BUILD_ASSERT(sizeof(ticks) <= sizeof(_PyTime_t));
+    t = (_PyTime_t)ticks;
+
+    if (_PyTime_check_mul_overflow(t, MS_TO_NS)) {
+        if (raise) {
+            _PyTime_overflow();
+            return -1;
+        }
+        /* Hello, time traveler! */
+        Py_UNREACHABLE();
+    }
+    *tp = t * MS_TO_NS;
+
+    if (info) {
+        DWORD timeAdjustment, timeIncrement;
+        BOOL isTimeAdjustmentDisabled, ok;
+        info->implementation = "GetTickCount64()";
+        info->monotonic = 1;
+        ok = GetSystemTimeAdjustment(&timeAdjustment, &timeIncrement,
+                                     &isTimeAdjustmentDisabled);
+        if (!ok) {
+            PyErr_SetFromWindowsErr(0);
+            return -1;
+        }
+        info->resolution = timeIncrement * 1e-7;
+        info->adjustable = 0;
+    }
+
+#elif defined(__APPLE__)
+    static mach_timebase_info_data_t timebase;
+    static uint64_t t0 = 0;
+    uint64_t ticks;
+
+    if (timebase.denom == 0) {
+        /* According to the Technical Q&A QA1398, mach_timebase_info() cannot
+           fail: https://developer.apple.com/library/mac/#qa/qa1398/ */
+        (void)mach_timebase_info(&timebase);
+
+        /* Sanity check: should never occur in practice */
+        if (timebase.numer < 1 || timebase.denom < 1) {
+            PyErr_SetString(PyExc_RuntimeError,
+                            "invalid mach_timebase_info");
+            return -1;
+        }
+
+        /* Check that timebase.numer and timebase.denom can be casted to
+           _PyTime_t. In practice, timebase uses uint32_t, so casting cannot
+           overflow. At the end, only make sure that the type is uint32_t
+           (_PyTime_t is 64-bit long). */
+        assert(sizeof(timebase.numer) < sizeof(_PyTime_t));
+        assert(sizeof(timebase.denom) < sizeof(_PyTime_t));
+
+        /* Make sure that (ticks * timebase.numer) cannot overflow in
+           _PyTime_MulDiv(), with ticks < timebase.denom.
+
+           Known time bases:
+
+           * always (1, 1) on Intel
+           * (1000000000, 33333335) or (1000000000, 25000000) on PowerPC
+
+           None of these time bases can overflow with 64-bit _PyTime_t, but
+           check for overflow, just in case. */
+        if ((_PyTime_t)timebase.numer > _PyTime_MAX / (_PyTime_t)timebase.denom) {
+            PyErr_SetString(PyExc_OverflowError,
+                            "mach_timebase_info is too large");
+            return -1;
+        }
+
+        t0 = mach_absolute_time();
+    }
+
+    if (info) {
+        info->implementation = "mach_absolute_time()";
+        info->resolution = (double)timebase.numer / (double)timebase.denom * 1e-9;
+        info->monotonic = 1;
+        info->adjustable = 0;
+    }
+
+    ticks = mach_absolute_time();
+    /* Use a "time zero" to reduce precision loss when converting time
+       to floatting point number, as in time.monotonic(). */
+    ticks -= t0;
+    *tp = _PyTime_MulDiv(ticks,
+                         (_PyTime_t)timebase.numer,
+                         (_PyTime_t)timebase.denom);
+
+#elif defined(__hpux)
+    hrtime_t time;
+
+    time = gethrtime();
+    if (time == -1) {
+        if (raise) {
+            PyErr_SetFromErrno(PyExc_OSError);
+        }
+        return -1;
+    }
+
+    *tp = time;
+
+    if (info) {
+        info->implementation = "gethrtime()";
+        info->resolution = 1e-9;
+        info->monotonic = 1;
+        info->adjustable = 0;
+    }
+
+#elif defined(HAVE_CLOCK_GETTIME)
+    struct timespec ts;
+#ifdef CLOCK_HIGHRES
+    const clockid_t clk_id = CLOCK_HIGHRES;
+    const char *implementation = "clock_gettime(CLOCK_HIGHRES)";
+#else
+    const clockid_t clk_id = CLOCK_MONOTONIC;
+    const char *implementation = "clock_gettime(CLOCK_MONOTONIC)";
+#endif
+
+    assert(info == NULL || raise);
+
+    if (clock_gettime(clk_id, &ts) != 0) {
+        if (raise) {
+            PyErr_SetFromErrno(PyExc_OSError);
+            return -1;
+        }
+        return -1;
+    }
+
+    if (info) {
+        struct timespec res;
+        info->monotonic = 1;
+        info->implementation = implementation;
+        info->adjustable = 0;
+        if (clock_getres(clk_id, &res) != 0) {
+            PyErr_SetFromErrno(PyExc_OSError);
+            return -1;
+        }
+        info->resolution = res.tv_sec + res.tv_nsec * 1e-9;
+    }
+    if (pytime_fromtimespec(tp, &ts, raise) < 0) {
+        return -1;
+    }
+
+#else
+    #warning "no implementation found for pymonotonic"
+#endif
+    return 0;
+}
+
+_PyTime_t
+_PyTime_GetMonotonicClock(void)
+{
+    _PyTime_t t;
+    if (pymonotonic(&t, NULL, 0) < 0) {
+        /* should not happen, _PyTime_Init() checked that monotonic clock at
+           startup */
+        Py_UNREACHABLE();
+    }
+    return t;
+}
+
+int
+_PyTime_GetMonotonicClockWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
+{
+    return pymonotonic(tp, info, 1);
+}
+
+
+#ifdef MS_WINDOWS
+static int
+win_perf_counter(_PyTime_t *tp, _Py_clock_info_t *info)
+{
+    static LONGLONG frequency = 0;
+    static LONGLONG t0 = 0;
+    LARGE_INTEGER now;
+    LONGLONG ticksll;
+    _PyTime_t ticks;
+
+    if (frequency == 0) {
+        LARGE_INTEGER freq;
+        if (!QueryPerformanceFrequency(&freq)) {
+            PyErr_SetFromWindowsErr(0);
+            return -1;
+        }
+        frequency = freq.QuadPart;
+
+        /* Sanity check: should never occur in practice */
+        if (frequency < 1) {
+            PyErr_SetString(PyExc_RuntimeError,
+                            "invalid QueryPerformanceFrequency");
+            return -1;
+        }
+
+        /* Check that frequency can be casted to _PyTime_t.
+
+           Make also sure that (ticks * SEC_TO_NS) cannot overflow in
+           _PyTime_MulDiv(), with ticks < frequency.
+
+           Known QueryPerformanceFrequency() values:
+
+           * 10,000,000 (10 MHz): 100 ns resolution
+           * 3,579,545 Hz (3.6 MHz): 279 ns resolution
+
+           None of these frequencies can overflow with 64-bit _PyTime_t, but
+           check for overflow, just in case. */
+        if (frequency > _PyTime_MAX
+            || frequency > (LONGLONG)_PyTime_MAX / (LONGLONG)SEC_TO_NS) {
+            PyErr_SetString(PyExc_OverflowError,
+                            "QueryPerformanceFrequency is too large");
+            return -1;
+        }
+
+        QueryPerformanceCounter(&now);
+        t0 = now.QuadPart;
+    }
+
+    if (info) {
+        info->implementation = "QueryPerformanceCounter()";
+        info->resolution = 1.0 / (double)frequency;
+        info->monotonic = 1;
+        info->adjustable = 0;
+    }
+
+    QueryPerformanceCounter(&now);
+    ticksll = now.QuadPart;
+
+    /* Use a "time zero" to reduce precision loss when converting time
+       to floatting point number, as in time.perf_counter(). */
+    ticksll -= t0;
+
+    /* Make sure that casting LONGLONG to _PyTime_t cannot overflow,
+       both types are signed */
+    Py_BUILD_ASSERT(sizeof(ticksll) <= sizeof(ticks));
+    ticks = (_PyTime_t)ticksll;
+
+    *tp = _PyTime_MulDiv(ticks, SEC_TO_NS, (_PyTime_t)frequency);
+    return 0;
+}
+#endif
+
+
+int
+_PyTime_GetPerfCounterWithInfo(_PyTime_t *t, _Py_clock_info_t *info)
+{
+#ifdef MS_WINDOWS
+    return win_perf_counter(t, info);
+#else
+    return _PyTime_GetMonotonicClockWithInfo(t, info);
+#endif
+}
+
+
+_PyTime_t
+_PyTime_GetPerfCounter(void)
+{
+    _PyTime_t t;
+    if (_PyTime_GetPerfCounterWithInfo(&t, NULL)) {
+        Py_UNREACHABLE();
+    }
+    return t;
+}
+
+
+int
+_PyTime_Init(void)
+{
+    /* check that time.time(), time.monotonic() and time.perf_counter() clocks
+       are working properly to not have to check for exceptions at runtime. If
+       a clock works once, it cannot fail in next calls. */
+    _PyTime_t t;
+    if (_PyTime_GetSystemClockWithInfo(&t, NULL) < 0) {
+        return -1;
+    }
+    if (_PyTime_GetMonotonicClockWithInfo(&t, NULL) < 0) {
+        return -1;
+    }
+    if (_PyTime_GetPerfCounterWithInfo(&t, NULL) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+int
+_PyTime_localtime(time_t t, struct tm *tm)
+{
+#ifdef MS_WINDOWS
+    int error;
+
+    error = localtime_s(tm, &t);
+    if (error != 0) {
+        errno = error;
+        PyErr_SetFromErrno(PyExc_OSError);
+        return -1;
+    }
+    return 0;
+#else /* !MS_WINDOWS */
+    if (localtime_r(&t, tm) == NULL) {
+#ifdef EINVAL
+        if (errno == 0) {
+            errno = EINVAL;
+        }
+#endif
+        PyErr_SetFromErrno(PyExc_OSError);
+        return -1;
+    }
+    return 0;
+#endif /* MS_WINDOWS */
+}
+
+int
+_PyTime_gmtime(time_t t, struct tm *tm)
+{
+#ifdef MS_WINDOWS
+    int error;
+
+    error = gmtime_s(tm, &t);
+    if (error != 0) {
+        errno = error;
+        PyErr_SetFromErrno(PyExc_OSError);
+        return -1;
+    }
+    return 0;
+#else /* !MS_WINDOWS */
+    if (gmtime_r(&t, tm) == NULL) {
+#ifdef EINVAL
+        if (errno == 0) {
+            errno = EINVAL;
+        }
+#endif
+        PyErr_SetFromErrno(PyExc_OSError);
+        return -1;
+    }
+    return 0;
+#endif /* MS_WINDOWS */
+}

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -97,7 +97,7 @@ Local naming conventions:
 
 #include "Python.h"
 #include "structmember.h"
-#include "timefuncs.h"
+#include "pytime.h"
 
 #ifndef INVALID_SOCKET /* MS defines this */
 #define INVALID_SOCKET (-1)

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -78,9 +78,6 @@ static long main_thread;
 #define timezone _timezone
 #define daylight _daylight
 #define tzname _tzname
-
-/* Win32 has better clock replacement; we have our own version below. */
-#undef HAVE_CLOCK
 #endif /* MS_WINDOWS && !defined(__BORLANDC__) */
 
 #if defined(PYOS_OS2)
@@ -262,9 +259,9 @@ time_clock(PyObject *self, PyObject *unused)
 {
     return pyclock(NULL);
 }
-#endif /* HAVE_CLOCK */
+#endif /* HAVE_CLOCK || MS_WINDOWS */
 
-#ifdef HAVE_CLOCK
+#ifdef PYCLOCK
 PyDoc_STRVAR(clock_doc,
 "clock() -> floating point number\n\
 \n\
@@ -1463,7 +1460,7 @@ inittimezone(PyObject *m) {
 static PyMethodDef time_methods[] = {
     {"time",            time_time, METH_NOARGS, time_doc},
     {"time_ns",         time_time_ns, METH_NOARGS, time_ns_doc},
-#ifdef HAVE_CLOCK
+#ifdef PYCLOCK
     {"clock",           time_clock, METH_NOARGS, clock_doc},
 #endif
 #ifdef HAVE_CLOCK_GETTIME

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1474,6 +1474,34 @@ inittime(void)
     /* Set, or reset, module variables like time.timezone */
     inittimezone(m);
 
+#ifdef CLOCK_REALTIME
+    PyModule_AddIntMacro(m, CLOCK_REALTIME);
+#endif
+#ifdef CLOCK_MONOTONIC
+    PyModule_AddIntMacro(m, CLOCK_MONOTONIC);
+#endif
+#ifdef CLOCK_MONOTONIC_RAW
+    PyModule_AddIntMacro(m, CLOCK_MONOTONIC_RAW);
+#endif
+#ifdef CLOCK_HIGHRES
+    PyModule_AddIntMacro(m, CLOCK_HIGHRES);
+#endif
+#ifdef CLOCK_PROCESS_CPUTIME_ID
+    PyModule_AddIntMacro(m, CLOCK_PROCESS_CPUTIME_ID);
+#endif
+#ifdef CLOCK_THREAD_CPUTIME_ID
+    PyModule_AddIntMacro(m, CLOCK_THREAD_CPUTIME_ID);
+#endif
+#ifdef CLOCK_PROF
+    PyModule_AddIntMacro(m, CLOCK_PROF);
+#endif
+#ifdef CLOCK_BOOTTIME
+    PyModule_AddIntMacro(m, CLOCK_BOOTTIME);
+#endif
+#ifdef CLOCK_UPTIME
+    PyModule_AddIntMacro(m, CLOCK_UPTIME);
+#endif
+
 #ifdef MS_WINDOWS
     /* Helper to allow interrupts for Windows.
        If Ctrl+C event delivered while not sleeping

--- a/PC/VS8.0/pythoncore.vcproj
+++ b/PC/VS8.0/pythoncore.vcproj
@@ -961,6 +961,9 @@
 			<File
 				RelativePath="..\..\Include\timefuncs.h"
 				>
+			<File
+				RelativePath="..\..\Include\pytime.h"
+				>
 			</File>
 			<File
 				RelativePath="..\..\Include\token.h"

--- a/PC/VS9.0/pythoncore.vcproj
+++ b/PC/VS9.0/pythoncore.vcproj
@@ -961,6 +961,9 @@
 			<File
 				RelativePath="..\..\Include\timefuncs.h"
 				>
+			<File
+				RelativePath="..\..\Include\pytime.h"
+				>
 			</File>
 			<File
 				RelativePath="..\..\Include\token.h"

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -159,20 +159,15 @@ WIN32 is still required for the locale module.
 #endif
 #endif /* MS_WIN64 */
 
-/* set the version macros for the windows headers */
-#ifdef MS_WINX64
-/* 64 bit only runs on XP or greater */
-#define Py_WINVER _WIN32_WINNT_WINXP
-#define Py_NTDDI NTDDI_WINXP
-#else
-/* Python 2.6+ requires Windows 2000 or greater */
+/* Set the version macros for the windows headers */
+
+/* Python 2.8+ requires Windows Vista or greater */
 #ifdef _WIN32_WINNT_WIN2K
-#define Py_WINVER _WIN32_WINNT_WIN2K
+#define Py_WINVER _WIN32_WINNT_VISTA
 #else
-#define Py_WINVER 0x0500
+#define Py_WINVER 0x0600
 #endif
-#define Py_NTDDI NTDDI_WIN2KSP4
-#endif
+#define Py_NTDDI NTDDI_VISTA
 
 /* We only set these values when building Python - we don't want to force
    these values on extensions, as that will affect the prototypes and

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -686,6 +686,9 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 /* Define if you have the <stddef.h> header file.  */
 #define HAVE_STDDEF_H 1
 
+/* Define if you have the <stdint.h> header file.  */
+#define HAVE_STDINT_H 1
+
 /* Define if you have the <sys/audioio.h> header file.  */
 /* #undef HAVE_SYS_AUDIOIO_H */
 

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -686,9 +686,6 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 /* Define if you have the <stddef.h> header file.  */
 #define HAVE_STDDEF_H 1
 
-/* Define if you have the <stdint.h> header file.  */
-#define HAVE_STDINT_H 1
-
 /* Define if you have the <sys/audioio.h> header file.  */
 /* #undef HAVE_SYS_AUDIOIO_H */
 

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -162,6 +162,7 @@
     <ClInclude Include="..\Include\symtable.h" />
     <ClInclude Include="..\Include\sysmodule.h" />
     <ClInclude Include="..\Include\timefuncs.h" />
+    <ClInclude Include="..\Include\pytime.h" />
     <ClInclude Include="..\Include\token.h" />
     <ClInclude Include="..\Include\traceback.h" />
     <ClInclude Include="..\Include\tupleobject.h" />
@@ -373,6 +374,7 @@
     <ClCompile Include="..\Python\pyctype.c" />
     <ClCompile Include="..\Python\pyfpe.c" />
     <ClCompile Include="..\Python\pymath.c" />
+    <ClCompile Include="..\Python\pytime.c" />
     <ClCompile Include="..\Python\pystate.c" />
     <ClCompile Include="..\Python\pystrcmp.c" />
     <ClCompile Include="..\Python\pystrtod.c" />

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -251,7 +251,6 @@
     <ClCompile Include="..\Modules\stropmodule.c" />
     <ClCompile Include="..\Modules\symtablemodule.c" />
     <ClCompile Include="..\Modules\threadmodule.c" />
-    <ClCompile Include="..\Modules\pytime.c" />
     <ClCompile Include="..\Modules\timemodule.c" />
     <ClCompile Include="..\Modules\xxsubtype.c" />
     <ClCompile Include="..\Modules\zipimport.c" />
@@ -375,6 +374,7 @@
     <ClCompile Include="..\Python\pyctype.c" />
     <ClCompile Include="..\Python\pyfpe.c" />
     <ClCompile Include="..\Python\pymath.c" />
+    <ClCompile Include="..\Python\pytime.c" />
     <ClCompile Include="..\Python\pystate.c" />
     <ClCompile Include="..\Python\pystrcmp.c" />
     <ClCompile Include="..\Python\pystrtod.c" />

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -143,6 +143,7 @@
     <ClInclude Include="..\Include\pygetopt.h" />
     <ClInclude Include="..\Include\pymactoolbox.h" />
     <ClInclude Include="..\Include\pymath.h" />
+    <ClInclude Include="..\Include\pymacro.h" />
     <ClInclude Include="..\Include\pymem.h" />
     <ClInclude Include="..\Include\pyport.h" />
     <ClInclude Include="..\Include\pystate.h" />

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -251,6 +251,7 @@
     <ClCompile Include="..\Modules\stropmodule.c" />
     <ClCompile Include="..\Modules\symtablemodule.c" />
     <ClCompile Include="..\Modules\threadmodule.c" />
+    <ClCompile Include="..\Modules\pytime.c" />
     <ClCompile Include="..\Modules\timemodule.c" />
     <ClCompile Include="..\Modules\xxsubtype.c" />
     <ClCompile Include="..\Modules\zipimport.c" />
@@ -374,7 +375,6 @@
     <ClCompile Include="..\Python\pyctype.c" />
     <ClCompile Include="..\Python\pyfpe.c" />
     <ClCompile Include="..\Python\pymath.c" />
-    <ClCompile Include="..\Python\pytime.c" />
     <ClCompile Include="..\Python\pystate.c" />
     <ClCompile Include="..\Python\pystrcmp.c" />
     <ClCompile Include="..\Python\pystrtod.c" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -279,7 +279,7 @@
     <ClInclude Include="..\Include\sysmodule.h">
       <Filter>Include</Filter>
     </ClInclude>
-    <ClInclude Include="..\Include\timefuncs.h">
+    <ClInclude Include="..\Include\pytime.h">
       <Filter>Include</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\token.h">

--- a/configure
+++ b/configure
@@ -11781,6 +11781,184 @@ fi
 done
 
 
+for ac_func in clock_gettime
+do :
+  ac_fn_c_check_func "$LINENO" "clock_gettime" "ac_cv_func_clock_gettime"
+if test "x$ac_cv_func_clock_gettime" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_CLOCK_GETTIME 1
+_ACEOF
+
+else
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for clock_gettime in -lrt" >&5
+$as_echo_n "checking for clock_gettime in -lrt... " >&6; }
+if ${ac_cv_lib_rt_clock_gettime+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lrt  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char clock_gettime ();
+int
+main ()
+{
+return clock_gettime ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_rt_clock_gettime=yes
+else
+  ac_cv_lib_rt_clock_gettime=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_rt_clock_gettime" >&5
+$as_echo "$ac_cv_lib_rt_clock_gettime" >&6; }
+if test "x$ac_cv_lib_rt_clock_gettime" = xyes; then :
+
+        LIBS="$LIBS -lrt"
+        $as_echo "#define HAVE_CLOCK_GETTIME 1" >>confdefs.h
+
+
+$as_echo "#define TIMEMODULE_LIB rt" >>confdefs.h
+
+
+fi
+
+
+fi
+done
+
+
+for ac_func in clock_getres
+do :
+  ac_fn_c_check_func "$LINENO" "clock_getres" "ac_cv_func_clock_getres"
+if test "x$ac_cv_func_clock_getres" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_CLOCK_GETRES 1
+_ACEOF
+
+else
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for clock_getres in -lrt" >&5
+$as_echo_n "checking for clock_getres in -lrt... " >&6; }
+if ${ac_cv_lib_rt_clock_getres+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lrt  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char clock_getres ();
+int
+main ()
+{
+return clock_getres ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_rt_clock_getres=yes
+else
+  ac_cv_lib_rt_clock_getres=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_rt_clock_getres" >&5
+$as_echo "$ac_cv_lib_rt_clock_getres" >&6; }
+if test "x$ac_cv_lib_rt_clock_getres" = xyes; then :
+
+        $as_echo "#define HAVE_CLOCK_GETRES 1" >>confdefs.h
+
+
+fi
+
+
+fi
+done
+
+
+for ac_func in clock_settime
+do :
+  ac_fn_c_check_func "$LINENO" "clock_settime" "ac_cv_func_clock_settime"
+if test "x$ac_cv_func_clock_settime" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_CLOCK_SETTIME 1
+_ACEOF
+
+else
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for clock_settime in -lrt" >&5
+$as_echo_n "checking for clock_settime in -lrt... " >&6; }
+if ${ac_cv_lib_rt_clock_settime+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lrt  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char clock_settime ();
+int
+main ()
+{
+return clock_settime ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_rt_clock_settime=yes
+else
+  ac_cv_lib_rt_clock_settime=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_rt_clock_settime" >&5
+$as_echo "$ac_cv_lib_rt_clock_settime" >&6; }
+if test "x$ac_cv_lib_rt_clock_settime" = xyes; then :
+
+        $as_echo "#define HAVE_CLOCK_SETTIME 1" >>confdefs.h
+
+
+fi
+
+
+fi
+done
+
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for major" >&5
 $as_echo_n "checking for major... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext

--- a/configure.ac
+++ b/configure.ac
@@ -3418,6 +3418,27 @@ AC_CHECK_FUNCS(gettimeofday,
     ])
 )
 
+AC_CHECK_FUNCS(clock_gettime, [], [
+    AC_CHECK_LIB(rt, clock_gettime, [
+        LIBS="$LIBS -lrt"
+        AC_DEFINE(HAVE_CLOCK_GETTIME, 1)
+        AC_DEFINE(TIMEMODULE_LIB, [rt],
+                  [Library needed by timemodule.c: librt may be needed for clock_gettime()])
+    ])
+])
+
+AC_CHECK_FUNCS(clock_getres, [], [
+    AC_CHECK_LIB(rt, clock_getres, [
+        AC_DEFINE(HAVE_CLOCK_GETRES, 1)
+    ])
+])
+
+AC_CHECK_FUNCS(clock_settime, [], [
+    AC_CHECK_LIB(rt, clock_settime, [
+        AC_DEFINE(HAVE_CLOCK_SETTIME, 1)
+    ])
+])
+
 AC_MSG_CHECKING(for major, minor, and makedev)
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #if defined(MAJOR_IN_MKDEV)

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -118,6 +118,15 @@
 /* Define to 1 if you have the `clock' function. */
 #undef HAVE_CLOCK
 
+/* Define to 1 if you have the `clock_getres' function. */
+#undef HAVE_CLOCK_GETRES
+
+/* Define to 1 if you have the `clock_gettime' function. */
+#undef HAVE_CLOCK_GETTIME
+
+/* Define to 1 if you have the `clock_settime' function. */
+#undef HAVE_CLOCK_SETTIME
+
 /* Define if the C compiler supports computed gotos. */
 #undef HAVE_COMPUTED_GOTOS
 
@@ -1139,6 +1148,9 @@
 
 /* Define if tanh(-0.) is -0., or if platform doesn't have signed zeros */
 #undef TANH_PRESERVES_ZERO_SIGN
+
+/* Library needed by timemodule.c: librt may be needed for clock_gettime() */
+#undef TIMEMODULE_LIB
 
 /* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
 #undef TIME_WITH_SYS_TIME

--- a/setup.py
+++ b/setup.py
@@ -601,9 +601,11 @@ class PyBuildExt(build_ext):
         # fast string operations implemented in C
         exts.append( Extension('strop', ['stropmodule.c']) )
         # time operations and variables
-        exts.append( Extension('time', ['timemodule.c'],
+        exts.append( Extension('time', ['timemodule.c', 'pytime.c'],
+                               depends=['pytime.h'],
                                libraries=math_libs) )
-        exts.append( Extension('datetime', ['datetimemodule.c', 'timemodule.c'],
+        exts.append( Extension('datetime', ['datetimemodule.c', 'timemodule.c', 'pytime.c'],
+                               depends=['pytime.h'],
                                libraries=math_libs) )
         # fast iterator tools implemented in C
         exts.append( Extension("itertools", ["itertoolsmodule.c"]) )
@@ -806,8 +808,8 @@ class PyBuildExt(build_ext):
         exts.append( Extension('_csv', ['_csv.c']) )
 
         # socket(2)
-        exts.append( Extension('_socket', ['socketmodule.c', 'timemodule.c'],
-                               depends=['socketmodule.h'],
+        exts.append( Extension('_socket', ['socketmodule.c', 'timemodule.c', 'pytime.c'],
+                               depends=['socketmodule.h', 'pytime.h'],
                                libraries=math_libs) )
         # Detect SSL support for the socket module (via _ssl)
         search_for_ssl_incs_in = [


### PR DESCRIPTION
This adds support for the monotonic timers in Python3's `time` module. The basic functions, `monotonic` and `monotonic_ns` were the original intention, but it was simple to add the others `process_time`, `process_time_ns`, `perf_counter`, and `perf_counter_ns`.

I skipped over `get_clock_info` because it might require a little bit of re-working. So if something in the future depends on this, lmk and I can include it by possibly substituting a named tuple for the namespace that it's supposed to return.

I've only tested this on Windows and Linux as those're the only two platforms that I have shells to. I also needed to modify the configuration a bit to add the `CLOCK_*` definitions that Python3 also checks for.

I also use the "HAVE_STDINT_H" definition to check for C99 support. I'm also not sure whether these new functions compile with a non-C99 compliant compiler (because who has one anyways).