### PR TITLE
setup.py: Small metadata update, replace official Python links

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2311,6 +2311,10 @@ on Windows, DOS, OS/2, Mac, Amiga... If your favorite system isn't
 listed here, it may still be supported, if there's a C compiler for
 it. Ask around on comp.lang.python -- or just try compiling Python
 yourself.
+
+This implementation, Tauthon, is a backward-compatible fork of
+Python's 2.7.18 interpreter with new syntax, builtins, and libraries
+backported from Python 3.x.
 """
 
 CLASSIFIERS = """
@@ -2329,9 +2333,9 @@ def main():
     setup(# PyPI Metadata (PEP 301)
           name = "Python",
           version = sys.version.split()[0],
-          url = "http://www.python.org/%s" % sys.version[:3],
-          maintainer = "Guido van Rossum and the Python community",
-          maintainer_email = "python-dev@python.org",
+          url = "https://github.com/naftaliharris/tauthon",
+          maintainer = "Guido van Rossum, the Python community \
+and the Tauthon developers",
           description = "A high-level object-oriented programming language",
           long_description = SUMMARY.strip(),
           license = "PSF license",


### PR DESCRIPTION
Make the package URL point to Tauthon's GitHub repository, and remove the
official Python's dev email. Add a small paragraph on Tauthon in the summary.

Did not change the project name to Tauthon, since doing this causes the final
egg to be renamed, and has the side-effect of making pip list Tauthon as an
installed package, which it doesn't do for "Python" (it is probably testing the
name, this should be patched for maximum compatibility when changing it).