### PR TITLE
Readline initialization fixes and better reporting

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -492,11 +492,25 @@ def enablerlcompleter():
             # http://bugs.python.org/issue5845#msg198636
             history = os.path.join(os.path.expanduser('~'),
                                    '.python_history')
+
             try:
                 readline.read_history_file(history)
-            except IOError:
+            except FileNotFoundError:
                 pass
-            atexit.register(readline.write_history_file, history)
+            except OSError as e:
+                warnings.warn("Cannot read readline history file: " +
+                              str(e),
+                              RuntimeWarning)
+
+            def write_history_file():
+                try:
+                    readline.write_history_file(history)
+                except OSError as e:
+                    warnings.warn("Cannot write readline history file: " +
+                                  str(e),
+                                  RuntimeWarning)
+
+            atexit.register(write_history_file)
 
     sys.__interactivehook__ = register_readline
 

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -65,6 +65,7 @@ import sys
 import os
 import __builtin__
 import traceback
+import warnings
 
 # Prefixes for site-packages; add additional prefixes like /usr/local here
 PREFIXES = [sys.prefix, sys.exec_prefix]
@@ -474,7 +475,14 @@ def enablerlcompleter():
             readline.parse_and_bind('bind ^I rl_complete')
         else:
             readline.parse_and_bind('tab: complete')
-        readline.read_init_file()
+
+        try:
+            readline.read_init_file()
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            warnings.warn("Cannot read readline init file: " + str(e),
+                          RuntimeWarning)
 
         if readline.get_current_history_length() == 0:
             # If no history was loaded, default to .python_history.

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -471,7 +471,7 @@ def enablerlcompleter():
 
         # Reading the initialization (config) file may not be enough to set a
         # completion key, so we set one first and then read the file
-        if 'libedit' in getattr(readline, '__doc__', ''):
+        if 'libedit' in (getattr(readline, '__doc__', '') or ''):
             readline.parse_and_bind('bind ^I rl_complete')
         else:
             readline.parse_and_bind('tab: complete')

--- a/Misc/NEWS.d/next/Library/2021-04-01-11-07-53.bpo-0.OZQVXU.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-01-11-07-53.bpo-0.OZQVXU.rst
@@ -1,0 +1,5 @@
+For interactive sessions, fix several :file:`site.py` Readline-related
+initialization problems, and have warnings printed when appropriate. Don't fail
+if there is no global Readline init file. Don't fail with ad-hoc Readline
+libraries. The history file is set up even if reading the default init files
+failed.

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -117,7 +117,9 @@ read_init_file(PyObject *self, PyObject *args)
 PyDoc_STRVAR(doc_read_init_file,
 "read_init_file([filename]) -> None\n\
 Execute a readline initialization file.\n\
-The default filename is the last filename used.");
+If filename is not specified, the last explicit one used in a preceding call\n\
+is used, or if none, one of the default ones as specified by Readline\n\
+(usually, the first one in env var INPUTRC, ~/.inputrc or /etc/inputrc).");
 
 
 /* Exported function to load a readline history file */


### PR DESCRIPTION
For interactive sessions, fix several `site.py` Readline-related
initialization problems, and have warnings printed when appropriate.

1. Don't fail if there is no global Readline init file.
2. Don't fail with ad-hoc Readline libraries.
3. The history file is set up even if reading the default init files failed.
