### PR TITLE
test.support.unlink: ignore EACCES

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -291,7 +291,7 @@ def unlink(filename):
     try:
         _unlink(filename)
     except OSError as exc:
-        if exc.errno not in (errno.ENOENT, errno.ENOTDIR):
+        if exc.errno not in (errno.ENOENT, errno.ENOTDIR, errno.EACCES):
             raise
 
 def rmdir(dirname):


### PR DESCRIPTION
Resolves test errors when running in the Gentoo sandbox environment: https://bugs.gentoo.org/679628