### PR TITLE
email.generator: fix handling of Unicode messages when not wrapping.

### DIFF
--- a/Lib/email/generator.py
+++ b/Lib/email/generator.py
@@ -28,7 +28,6 @@ def _is8bitstring(s):
     return False
 
 
-
 class Generator:
     """Generates output from a Message object tree.
 
@@ -142,7 +141,7 @@ class Generator:
             print >> self._fp, '%s:' % h,
             if self._maxheaderlen == 0:
                 # Explicit no-wrapping
-                print >> self._fp, v
+                print >> self._fp, v.encode()
             elif isinstance(v, Header):
                 # Header instances know what to do
                 print >> self._fp, v.encode()
@@ -290,7 +289,6 @@ class Generator:
         self._fp.write(payload)
 
 
-
 _FMT = '[Non-text (%(type)s) part of message omitted, filename %(filename)s]'
 
 class DecodedGenerator(Generator):
@@ -348,7 +346,6 @@ class DecodedGenerator(Generator):
                     }
 
 
-
 # Helper
 _width = len(repr(sys.maxint-1))
 _fmt = '%%0%dd' % _width

--- a/Lib/email/message.py
+++ b/Lib/email/message.py
@@ -34,7 +34,7 @@ def _splitparam(param):
     if not sep:
         return a.strip(), None
     return a.strip(), b.strip()
-
+
 def _formatparam(param, value=None, quote=True):
     """Convenience function to format and return a key=value pair.
 
@@ -88,7 +88,7 @@ def _unquotevalue(value):
         return utils.unquote(value)
 
 
-
+
 class Message:
     """Basic message object.
 

--- a/Misc/NEWS.d/next/Library/2023-02-04-13-08-14.gh-issue-1.CSSQMg.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-04-13-08-14.gh-issue-1.CSSQMg.rst
@@ -1,0 +1,3 @@
+email.generator: fix handling of Unicode messages when not wrapping.
+
+Problem observed when creating a wheel for scandir-1.10.0.


### PR DESCRIPTION
Problem observed when creating a wheel for scandir-1.10.0.