### PR TITLE
configure: fix implicit declaration of "close()"

### DIFF
--- a/configure
+++ b/configure
@@ -16569,6 +16569,7 @@ else $as_nop
 /* end confdefs.h.  */
 
 #include <poll.h>
+#include <unistd.h>
 
 int main()
 {

--- a/configure.ac
+++ b/configure.ac
@@ -4404,6 +4404,7 @@ AC_MSG_CHECKING(for broken poll())
 AC_CACHE_VAL(ac_cv_broken_poll,
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <poll.h>
+#include <unistd.h>
 
 int main()
 {


### PR DESCRIPTION
See also: https://wiki.gentoo.org/wiki/Modern_C_porting